### PR TITLE
Only simulate beta-binomial for ER source

### DIFF
--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -733,12 +733,15 @@ class Source(SourceBase):
 
         d['energy'] = energies
         d['nq'] = s._simulate_nq(energies)
-
         d['p_el_mean'] = gimme('p_electron', d['nq'].values)
-        d['p_el_fluct'] = gimme('p_electron_fluctuation', d['nq'].values)
 
-        d['p_el_actual'] = stats.beta.rvs(
-            *fd.beta_params(d['p_el_mean'], d['p_el_fluct']))
+        if s.do_pel_fluct:
+            d['p_el_fluct'] = gimme('p_electron_fluctuation', d['nq'].values)
+            d['p_el_actual'] = stats.beta.rvs(
+                *fd.beta_params(d['p_el_mean'], d['p_el_fluct']))
+        else:
+            d['p_el_fluct'] = 0.
+            d['p_el_actual'] = d['p_el_mean']
         d['p_el_actual'] = np.nan_to_num(d['p_el_actual']).clip(0, 1)
         d['electron_produced'] = stats.binom.rvs(
             n=d['nq'],


### PR DESCRIPTION
This fixes a bug in the simulator which was using the beta-binomial distribution for both ER and NR sources to simulate events. It now correctly uses the beta-binomial for ER and the binomial for NR.

This solves issue #12 

Before the MC likelihood did not match the full likelihood for NR sources:
![nr_mc_comparison](https://user-images.githubusercontent.com/8984694/64780174-fc1ed800-d55f-11e9-80bc-16d445a2c567.png)

After:
![nr_mc_comparison_fixed](https://user-images.githubusercontent.com/8984694/64780182-02ad4f80-d560-11e9-8ff7-292346a90810.png)
