### PR TITLE
Compute beta-binomial pmf on photons instead of electrons

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -336,9 +336,9 @@ class LXeSource(fd.Source):
             pel_fluct = fd.lookup_axis1(pel_fluct, _nq_ind)
             pel_fluct = tf.clip_by_value(pel_fluct, fd.MIN_FLUCTUATION_P, 1.)
             return rate_nq * fd.beta_binom_pmf(
-                nel,
+                nph,
                 n=nq,
-                p_mean=pel,
+                p_mean=1. - pel,
                 p_sigma=pel_fluct)
 
         else:
@@ -346,7 +346,7 @@ class LXeSource(fd.Source):
                 total_count=nq, probs=pel).prob(nel)
 
     def detection_p(self, quanta_type, data_tensor, ptensor):
-        """Return (n_events, |detected|, |produced|) te nsor
+        """Return (n_events, |detected|, |produced|) tensor
         encoding P(n_detected | n_produced)
         """
         n_det, n_prod = self.cross_domains(quanta_type + '_detected',

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -107,13 +107,13 @@ def tf_log10(x):
 
 @export
 def safe_p(ps):
-    """Clip probabilities to be in [1e-5, MAX_MEAN_P]
+    """Clip probabilities to be in [1e-5, 1 - 1e-5]
     NaNs are replaced by 1e-5.
     """
     ps = tf.where(tf.math.is_nan(ps),
                   tf.zeros_like(ps, dtype=float_type()),
                   tf.cast(ps, dtype=float_type()))
-    ps = tf.clip_by_value(ps, 1e-5, MAX_MEAN_P)
+    ps = tf.clip_by_value(ps, 1e-5, 1 - 1e-5)
     return ps
 
 


### PR DESCRIPTION
To solve issue #37, this PR changes the computation of the beta binomial pmf. Instead of computing the probability of observing a number of electrons given `p_electron` we compute the probability of observing a number of photons given `1 - p_electron` (`p_electron_fluctuation` remaining the same).
This prevents large `p_electron` values being used resulting in numerical errors.
We could consider removing or relaxing the `MAX_MEAN_P` and `MIN_FLUCTUATION_P` bounds. I've reverted `safe_p`, but kept the check inside `beta_binom_pmf` since there it checks `1 - p_mean` but it might be better to rename it.
`MIN_FLUCTUATION_P` we could keep for the moment.