### PR TITLE
Add Minuit optimiser and update NRSource

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -411,7 +411,7 @@ class LogLikelihood:
                 kwargs.setdefault('f_relative_tolerance',
                                  llr_tolerance/self.minus_ll(**guess)[0])
 
-            res = optimizer(self.objective,
+            res = optimizer(self.objective_tf,
                             x_guess,
                             initial_inverse_hessian_estimate=inv_hess,
                             **kwargs)

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -412,7 +412,7 @@ class LogLikelihood:
                                  llr_tolerance/self.minus_ll(**guess)[0])
 
             res = optimizer(self.objective,
-                            x_norm,
+                            x_guess,
                             initial_inverse_hessian_estimate=inv_hess,
                             **kwargs)
             if get_lowlevel_result:
@@ -437,7 +437,7 @@ class LogLikelihood:
             autograph=self._autograph_objective,
             omit_grads=tuple(self._fix.keys()))
         if tf.math.is_nan(ll):
-            tf.print(f"Objective at {tf.math.abs(x_norm)} is Nan!")
+            tf.print(f"Objective at {x_guess} is Nan!")
             ll *= float('inf')
             grad *= float('nan')
         return ll, grad 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -337,9 +337,8 @@ class LogLikelihood:
                 optimizer= Minuit.from_array_func,
                 llr_tolerance=0.1,
                 get_lowlevel_result=False,
-                use_hessian=False,
+                use_hessian=True,
                 autograph=True,
-                precision=None,
                 **kwargs):
         """Return best-fit parameter tensor
 
@@ -393,8 +392,10 @@ class LogLikelihood:
                            name = self._varnames,
                            **kwargs)
             
-            fit.migrad(precision=precision)
+            fit.migrad()
             fit_result = dict(fit.values)
+            if use_hessian:
+                fit.hesse()
             fit_errors = dict()
             for (k, v) in fit.errors.items():
                 fit_errors[k + '_error'] = v
@@ -441,7 +442,7 @@ class LogLikelihood:
 
     def objective_numpy(self, x_guess):
         ll, grad = self.objective_tf(fd.np_to_tf(x_guess))
-    return ll.numpy(), grad.numpy()
+        return ll.numpy(), grad.numpy()
 
     #TODO: make a nice wrapper for objective and gradient
     def objective_minuit(self, x_guess):

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -435,7 +435,7 @@ class LogLikelihood:
             autograph=self._autograph_objective,
             omit_grads=tuple(self._fix.keys()))
         if tf.math.is_nan(ll):
-            tf.print(f"Objective at {x_norm} is Nan!")
+            tf.print(f"Objective at {x_guess} is Nan!")
             ll *= float('inf')
             grad *= float('nan')
         return ll, grad 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -422,7 +422,7 @@ class LogLikelihood:
                 raise ValueError(f"Optimizer failure! Result: {res}")
             res = res.position
             res = {k: res[i].numpy() for i, k in enumerate(self._varnames)}
-            return {**res, **fix}
+            return {**res, **fix}, dict()
         
     def objective_tf(self, x_guess):
         # Fill in the fixed variables / convert to dict

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -419,6 +419,7 @@ class LogLikelihood:
                 return res
             if res.failed:
                 raise ValueError(f"Optimizer failure! Result: {res}")
+            res = res.position
             res = {k: res[i].numpy() for i, k in enumerate(self._varnames)}
             return {**res, **fix}
         

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -71,7 +71,7 @@ class SR1Source:
 
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
-    def photon_detection_eff(s1_relative_ly, g1 =0.123): 
+    def photon_detection_eff(s1_relative_ly, g1 =0.142): 
         #g1 = 0.142 from paper
         mean_eff= g1 / (1. + 0.219)
         return mean_eff * s1_relative_ly
@@ -118,6 +118,46 @@ class SR1ERSource(SR1Source,fd.ERSource):
 class SR1NRSource(SR1Source, fd.NRSource):
     extra_needed_columns = tuple(set(
         list(SR1Source.extra_needed_columns) + 
-        list(fd.NRSource.extra_needed_columns)))
+        list(fd.NRSource.extra_needed_columns)+
+        ['x_observed', 'y_observed']))
+
+    def p_electron(self, nq, *,
+            alpha=1.280, zeta=0.045, beta=273 * .9e-4, 
+            gamma=0.0141, delta=0.062,
+            drift_field=81):
+        """Fraction of detectable NR quanta that become electrons,
+        slightly adjusted from Lenardo et al.'s global fit
+        (https://arxiv.org/abs/1412.4417).
+
+        Penning quenching is accounted in the photon detection efficiency.
+        """
+        # TODO: so to make field pos-dependent, override this entire f?
+        # could be made easier...
+
+        # prevent /0  # TODO can do better than this
+        nq = nq + 1e-9
+
+        # Note: final term depends on nq now, not energy
+        # this means beta is different from lenardo et al
+        nexni = alpha * drift_field ** -zeta * (1 - tf.exp(-beta * nq))
+        ni = nq * 1 / (1 + nexni)
+
+        # Fraction of ions NOT participating in recombination
+        squiggle = gamma * drift_field ** -delta
+        fnotr = tf.math.log(1 + ni * squiggle) / (ni * squiggle)
+
+        # Finally, number of electrons produced..
+        n_el = ni * fnotr
+
+        return fd.safe_p(n_el / nq)
+    
+    #TODO: Define the proper nr spectrum
+    #def _single_spectrum(self):
+    #    """Return (energies in keV, events at these energies),
+    #    both (n_events, n_energies) tensors.
+    #    """   
+    #    e = fd.np_to_tf(spectrum_df['rec_energy'])
+    #    ev = fd.np_to_tf(spectrum_df['rate']) 
+    #    return e, ev   
 
 # TODO: Modify the SR1NRSource to fit AmBe data better and add WIMPSource

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -152,12 +152,5 @@ class SR1NRSource(SR1Source, fd.NRSource):
         return fd.safe_p(n_el / nq)
     
     #TODO: Define the proper nr spectrum
-    #def _single_spectrum(self):
-    #    """Return (energies in keV, events at these energies),
-    #    both (n_events, n_energies) tensors.
-    #    """   
-    #    e = fd.np_to_tf(spectrum_df['rec_energy'])
-    #    ev = fd.np_to_tf(spectrum_df['rate']) 
-    #    return e, ev   
 
 # TODO: Modify the SR1NRSource to fit AmBe data better and add WIMPSource

--- a/notebooks/Tutorial.ipynb
+++ b/notebooks/Tutorial.ipynb
@@ -37,7 +37,7 @@
         "#!pip install flamedisx\n",
         "\n",
         "### In case you want to develop Flamedisx you can clone the repository\n",
-        "#!git clone https://github.com/JelleAalbers/flamedisx.git\n",
+        "#!git clone https://github.com/FlamTeam/flamedisx.git\n",
         "\n",
         "# Install flamedisx\n",
         "#%cd flamedisx\n",
@@ -60,7 +60,7 @@
         "# Install Tensorflow\n",
         "# Install TF2 and TFP w GPU support (change runtime to GPU to test)\n",
         "#!pip install -U tensorflow-gpu==2.0.0\n",
-        "#!pip install -U tensorflow_probability==0.8.0"
+        "#!pip install -U tensorflow_probability==0.8.0\n"
       ],
       "execution_count": 0,
       "outputs": []
@@ -299,7 +299,7 @@
         "colab": {}
       },
       "source": [
-        "smalld = fd.ERSource().simulate(25)"
+        "smalld = fd.ERSource().simulate(250)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -413,7 +413,7 @@
       "source": [
         "%%time\n",
         "bestfit = ll.bestfit(guess=dict(er_rate_multiplier=0.03, elife=410e3))\n",
-        "ll.summary(bestfit)"
+        "ll.summary(bestfit[0])"
       ],
       "execution_count": 0,
       "outputs": []
@@ -438,7 +438,7 @@
         "colab": {}
       },
       "source": [
-        "inv_h = ll.inverse_hessian(bestfit)"
+        "inv_h = ll.inverse_hessian(bestfit[0])"
       ],
       "execution_count": 0,
       "outputs": []
@@ -461,7 +461,7 @@
         "colab": {}
       },
       "source": [
-        "ll.summary(bestfit, inverse_hessian=inv_h)"
+        "ll.summary(bestfit[0], inverse_hessian=inv_h)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -571,7 +571,7 @@
       "source": [
         "%%time\n",
         "bf2 = ll2.bestfit(guess=dict(er_rate_multiplier=0.014, absorption_length=66.))\n",
-        "ll2.summary(bf2)"
+        "ll2.summary(bf2[0])"
       ],
       "execution_count": 0,
       "outputs": []
@@ -697,7 +697,7 @@
       "source": [
         "%%time\n",
         "bf3 = ll3.bestfit(guess=dict(er_rate_multiplier=0.012))\n",
-        "ll3.summary(bf3)"
+        "ll3.summary(bf3[0])"
       ],
       "execution_count": 0,
       "outputs": []
@@ -749,7 +749,7 @@
         "        \n",
         "plot_nq(plot_kwargs=dict(label='Truth'))\n",
         "plot_nq(MyERSource,  plot_kwargs=dict(label='Guess'), twin=False)\n",
-        "plot_nq(MyERSource,  plot_kwargs=dict(label='Fit'), twin=False, **bf3)\n",
+        "plot_nq(MyERSource,  plot_kwargs=dict(label='Fit'), twin=False, **bf3[0])\n",
         "plt.legend(loc='upper right')"
       ],
       "execution_count": 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ wimprates
 tqdm
 tensorflow==2.0.0
 tensorflow_probability==0.8.0
+iminuit

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -257,7 +257,7 @@ def test_bestfit_minuit(xes):
     guess['er_rate_multiplier'] = xs[np.argmin(ys)]
     assert len(guess) == 2
 
-    bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, limit = ((0,1),(100e3, 500e3)))
+    bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, error = (0.0001,1000))
     assert isinstance(bestfit[0], dict)
     assert len(bestfit[0]) == 2
-    assert bestfit[0]['er_rate_multiplier'].dtype == np.float32
+    

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -213,7 +213,7 @@ def test_hessian(xes: fd.ERSource):
     assert abs(a - b)/(a+b) < 1e-3
 
 
-def test_bestfit(xes):
+def test_bestfit_tf(xes):
     # Test bestfit (including hessian)
     lf = fd.LogLikelihood(
         sources=dict(er=xes.__class__),
@@ -231,7 +231,31 @@ def test_bestfit(xes):
     guess['er_rate_multiplier'] = xs[np.argmin(ys)]
     assert len(guess) == 2
 
-    bestfit = lf.bestfit(guess, use_hessian=True)
+    bestfit = lf.bestfit(guess, optimizer=tfp.optimizer.bfgs_minimize, use_hessian=True)
+    assert isinstance(bestfit, dict)
+    assert len(bestfit) == 2
+    assert bestfit['er_rate_multiplier'].dtype == np.float32
+
+
+def test_bestfit_minuit(xes):
+    # Test bestfit (including hessian)
+    lf = fd.LogLikelihood(
+        sources=dict(er=xes.__class__),
+        elife=(100e3, 500e3, 5),
+        free_rates='er',
+        data=xes.data)
+
+    guess = lf.guess()
+    # Set reasonable rate
+    # Evaluate the likelihood curve around the minimum
+    xs_er = np.linspace(0.001, 0.004, 20)  # ER source range
+    xs_nr = np.linspace(0.04, 0.1, 20)  # NR source range
+    xs = list(xs_er) + list(xs_nr)
+    ys = np.array([-lf(er_rate_multiplier=x) for x in xs])
+    guess['er_rate_multiplier'] = xs[np.argmin(ys)]
+    assert len(guess) == 2
+
+    bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, limit = ((0,1),(100e3, 500e3)))
     assert isinstance(bestfit, dict)
     assert len(bestfit) == 2
     assert bestfit['er_rate_multiplier'].dtype == np.float32

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -259,5 +259,5 @@ def test_bestfit_minuit(xes):
 
     bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, limit = ((0,1),(100e3, 500e3)))
     assert isinstance(bestfit[0], dict)
-    assert len(bestfit) == 2
-    assert bestfit['er_rate_multiplier'].dtype == np.float32
+    assert len(bestfit[0]) == 2
+    assert bestfit[0]['er_rate_multiplier'].dtype == np.float32

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import tensorflow as tf
+import tensorflow_probability as tfp
+from iminuit import Minuit
 
 import flamedisx as fd
 from flamedisx.inference import DEFAULT_DSETNAME

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -234,9 +234,9 @@ def test_bestfit_tf(xes):
     assert len(guess) == 2
 
     bestfit = lf.bestfit(guess, optimizer=tfp.optimizer.bfgs_minimize, use_hessian=True)
-    assert isinstance(bestfit, dict)
-    assert len(bestfit) == 2
-    assert bestfit['er_rate_multiplier'].dtype == np.float32
+    assert isinstance(bestfit[0], dict)
+    assert len(bestfit[0]) == 2
+    assert bestfit[0]['er_rate_multiplier'].dtype == np.float32
 
 
 def test_bestfit_minuit(xes):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -258,6 +258,6 @@ def test_bestfit_minuit(xes):
     assert len(guess) == 2
 
     bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, limit = ((0,1),(100e3, 500e3)))
-    assert isinstance(bestfit, dict)
+    assert isinstance(bestfit[0], dict)
     assert len(bestfit) == 2
     assert bestfit['er_rate_multiplier'].dtype == np.float32


### PR DESCRIPTION
In this pull request I have added the Minuit optimiser and updated the NRSource for SR1.

Further more as discussed in issue #36 I have taken out the scaling of the parameters in the optimiser since it seemed to give problems with the error computation. 

The Minuit optimiser needs some polishing but from testing seems to work very well and the computation time penalty doesn't seem to be too great (roughly a factor 2) with respect to the tensorflow optimiser. 

The main advantage of Minuit comes from the fact that bounds can be given to the parameters and this avoids the useless stepping into negative parameter values and nan-s from the objective function. 

Possible improvements to this implementation are: 
 - give automatic bounds to the parameters and not leave them as keyword arguments
 - give initial step size as a percentage of the guess params 
 - figure out how the precision of migrad works and give an appropriate value as default (and not necessarily use the internal migrad precision) 
 - compute and return the Hesse errors of Minuit and compare with our implementation 