### PR TITLE
Construct Likelihood without data

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -94,8 +94,8 @@ class LogLikelihood:
 
         # Create sources. Have to copy data, it's modified by set_data
         self.sources = {
-            d = data[self.d_for_s[sname]]
-            sname: sclass(data=None if d is None else d.copy(),
+            sname: sclass(data=None if data[self.d_for_s[sname]] is None \
+                            else data[self.d_for_s[sname]].copy(),
                           max_sigma=max_sigma,
                           fit_params=list(common_param_specs.keys()),
                           batch_size=batch_size)

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -36,7 +36,10 @@ class LogLikelihood:
             sources: ty.Union[
                 ty.Dict[str, fd.Source.__class__],
                 ty.Dict[str, ty.Dict[str, fd.Source.__class__]]],
-            data: ty.Union[pd.DataFrame, ty.Dict[str, pd.DataFrame]],
+            data: ty.Union[
+                None,
+                pd.DataFrame,
+                ty.Dict[str, pd.DataFrame]] = None,
             free_rates: ty.Union[None, str, ty.Tuple[str]] = None,
             batch_size=10,
             max_sigma=3,
@@ -49,7 +52,8 @@ class LogLikelihood:
         or just {sourcename: class} in case you have one dataset
         Every source name must be unique.
         :param data: Dictionary {datasetname: pd.DataFrame}
-        or just pd.DataFrame if you have one dataset
+        or just pd.DataFrame if you have one dataset or None if you
+        set data later.
         :param free_rates: names of sources whose rates are floating
         :param batch_size:
         :param max_sigma:
@@ -59,7 +63,7 @@ class LogLikelihood:
 
         param_defaults = dict()
 
-        if isinstance(data, pd.DataFrame):
+        if isinstance(data, pd.DataFrame) or data is None:
             # Only one dataset
             data = {DEFAULT_DSETNAME: data}
         if not isinstance(list(sources.values())[0], dict):
@@ -90,7 +94,8 @@ class LogLikelihood:
 
         # Create sources. Have to copy data, it's modified by set_data
         self.sources = {
-            sname: sclass(data[self.d_for_s[sname]].copy(),
+            d = data[self.d_for_s[sname]]
+            sname: sclass(data=None if d is None else d.copy(),
                           max_sigma=max_sigma,
                           fit_params=list(common_param_specs.keys()),
                           batch_size=batch_size)

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -94,8 +94,9 @@ class LogLikelihood:
 
         # Create sources. Have to copy data, it's modified by set_data
         self.sources = {
-            sname: sclass(data=None if data[self.d_for_s[sname]] is None \
-                            else data[self.d_for_s[sname]].copy(),
+            sname: sclass(data=(None
+                                if data[self.d_for_s[sname]] is None
+                                else data[self.d_for_s[sname]].copy()),
                           max_sigma=max_sigma,
                           fit_params=list(common_param_specs.keys()),
                           batch_size=batch_size)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -18,6 +18,9 @@ o = tf.newaxis
 class SourceBase:
     """Base class of Source"""
 
+    n_batches = None
+    batch_size = None
+    n_padding = None
     trace_difrate = True
 
     def _init_padding(self, batch_size, _skip_tf_init):

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -28,7 +28,15 @@ class SourceBase:
         self.n_events = len(self.data)
 
         if hasattr(self, 'batch_size'):
+            # We have self.batch_size so the Source has been initialized before
+            # meaning we cannot change the batch_size anymore, check that we
+            # are not trying to change it by accident
             assert batch_size is None
+
+            # However, we still have to check if the new data being set is
+            # not less than half the batch size or the padding wont work
+            assert self.n_events * 2 >= self.batch_size, ("batch_size "
+                f"{self.batch_size} is too small for {self.n_events} events")
         else:
             if batch_size is None or batch_size > self.n_events or _skip_tf_init:
                 batch_size = self.n_events

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -19,7 +19,6 @@ class SourceBase:
     """Base class of Source"""
 
     n_batches = None
-    batch_size = None
     n_padding = None
     trace_difrate = True
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -105,21 +105,18 @@ def test_no_dset(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=fd.ERSource),
         data=None)
-    ll1 = lf()
 
     lf2 = fd.LogLikelihood(
         sources=dict(data1=dict(er1=fd.ERSource),
                      data2=dict(er2=fd.ERSource)),
         data=dict(data1=None,
                   data2=None))
-    ll2 = lf2()
 
 
 def test_set_data_on_no_dset(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=fd.ERSource),
         data=None)
-    ll1 = lf()
 
     lf.set_data(xes.data.copy())
     ll1 = lf()
@@ -129,7 +126,6 @@ def test_set_data_on_no_dset(xes: fd.ERSource):
                      data2=dict(er2=fd.ERSource)),
         data=dict(data1=None,
                   data2=None))
-    ll2 = lf2()
 
     lf2.set_data(dict(data1=xes.data.copy(),
                       data2=xes.data.copy()))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -119,6 +119,10 @@ def test_set_data_on_no_dset(xes: fd.ERSource):
         data=None)
 
     lf.set_data(xes.data.copy())
+
+    assert lf.sources['er'].batch_size == 10
+    assert lf.sources['er'].n_batches == 1
+    assert lf.sources['er'].n_padding == 8
     ll1 = lf()
 
     lf2 = fd.LogLikelihood(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -116,7 +116,13 @@ def test_no_dset(xes: fd.ERSource):
 def test_set_data_on_no_dset(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=fd.ERSource),
-        data=None)
+        data=None,
+        batch_size=4)
+    # The batch_size can be at most 2 * len(data) or padding wont work
+    # which is why it is set explicitly in this test with only 2 events
+    # Usually when constructing the likelihood with a very small dataset
+    # the batch_size is set accordingly, but in this test with data=None
+    # that is not possible (an assert has been put in Source._init_padding)
 
     lf.set_data(xes.data.copy())
 
@@ -129,7 +135,8 @@ def test_set_data_on_no_dset(xes: fd.ERSource):
         sources=dict(data1=dict(er1=fd.ERSource),
                      data2=dict(er2=fd.ERSource)),
         data=dict(data1=None,
-                  data2=None))
+                  data2=None),
+        batch_size=4)
 
     lf2.set_data(dict(data1=xes.data.copy(),
                       data2=xes.data.copy()))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -101,6 +101,41 @@ def test_columnsource(xes: fd.ERSource):
     np.testing.assert_almost_equal(lf(), -3.14 + len(xes.data) * np.log(5.))
 
 
+def test_no_dset(xes: fd.ERSource):
+    lf = fd.LogLikelihood(
+        sources=dict(er=fd.ERSource),
+        data=None)
+    ll1 = lf()
+
+    lf2 = fd.LogLikelihood(
+        sources=dict(data1=dict(er1=fd.ERSource),
+                     data2=dict(er2=fd.ERSource)),
+        data=dict(data1=None,
+                  data2=None))
+    ll2 = lf2()
+
+
+def test_set_data_on_no_dset(xes: fd.ERSource):
+    lf = fd.LogLikelihood(
+        sources=dict(er=fd.ERSource),
+        data=None)
+    ll1 = lf()
+
+    lf.set_data(xes.data.copy())
+    ll1 = lf()
+
+    lf2 = fd.LogLikelihood(
+        sources=dict(data1=dict(er1=fd.ERSource),
+                     data2=dict(er2=fd.ERSource)),
+        data=dict(data1=None,
+                  data2=None))
+    ll2 = lf2()
+
+    lf2.set_data(dict(data1=xes.data.copy(),
+                      data2=xes.data.copy()))
+    ll2 = lf2()
+
+
 def test_multi_dset(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=fd.ERSource),
@@ -169,6 +204,7 @@ def test_set_data(xes: fd.ERSource):
     lf.set_data(dict(data2=data1))
 
     pd.testing.assert_series_equal(internal_data('er2', 's1'), data1['s1'])
+
 
 def test_constraint(xes: fd.ERSource):
     lf = fd.LogLikelihood(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -126,9 +126,9 @@ def test_set_data_on_no_dset(xes: fd.ERSource):
 
     lf.set_data(xes.data.copy())
 
-    assert lf.sources['er'].batch_size == 10
+    assert lf.sources['er'].batch_size == 4
     assert lf.sources['er'].n_batches == 1
-    assert lf.sources['er'].n_padding == 8
+    assert lf.sources['er'].n_padding == 2
     ll1 = lf()
 
     lf2 = fd.LogLikelihood(


### PR DESCRIPTION
This PR implements construction of likelihoods without data to solve issue #26.

`LogLikelihood` can now be initialized with `data=None`, then call `set_data(data)` on your likelihood later to set dataset `data`. Take care to choose an appropriate `batch_size` in case you are dealing with small datasets (the number of events needs to be at least half the batch size for the padding to work). When passing very small datasets to the initializer (of either Source or LogLikelihood) `batch_size` is adjusted but this is of course not possible when `data=None`. I've added an assert for this in the `Source._init_padding` and tests for constructing single and multiple source likelihoods without data.