### PR TITLE
Likelihood simulate

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -172,7 +172,7 @@ class LogLikelihood:
             if rmname in rate_multipliers:
                 rm = rate_multipliers[rmname]
             else:
-                rm = self._get_rate_mult(sname, **params)
+                rm = self._get_rate_mult(sname, params)
 
             # mean number of events to simulate, rate mult times mu source
             mu = rm * self.mu_itps[sname](**self._filter_source_kwargs(params,

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -178,9 +178,11 @@ class LogLikelihood:
             mu = rm * self.mu_itps[sname](**self._filter_source_kwargs(params,
                                                                        sname))
             # Simulate events from source
-            ds.append(s.simulate(np.random.poisson(mu),
-                                 fix_truth=fix_truth,
-                                 **params))
+            d = s.simulate(np.random.poisson(mu),
+                           fix_truth=fix_truth,
+                           **params)
+            d['source'] = sname
+            ds.append(d)
         # Concatenate results and shuffle them
         return pd.concat(ds, sort=False).sample(frac=1).reset_index(drop=True)
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -182,7 +182,7 @@ class LogLikelihood:
                                  fix_truth=fix_truth,
                                  **params))
         # Concatenate results and shuffle them
-        return pd.concat(ds).sample(frac=1).reset_index(drop=True)
+        return pd.concat(ds, sort=False).sample(frac=1).reset_index(drop=True)
 
     def __call__(self, **kwargs):
         assert 'second_order' not in kwargs, 'Roep gewoon log_likelihood aan'

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -122,6 +122,17 @@ def test_multi_dset(xes: fd.ERSource):
     np.testing.assert_almost_equal(2 * ll1, ll2)
 
 
+def test_simulate(xes):
+    # Once PR #43 merged we can set data=None here
+    lf = fd.LogLikelihood(
+        sources=dict(er=fd.ERSource),
+        data=xes.data.copy())
+
+    events = lf.simulate()
+    events = lf.simulate(rate_multipliers=dict('er_rate_multiplier'=2.)
+    events = lf.simulate(fix_truth=dict(x=0., y=0., z=-50.))
+
+
 def test_set_data(xes: fd.ERSource):
     data1 = xes.data
     data2 = pd.concat([data1.copy(), data1.iloc[:1].copy()])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -129,7 +129,7 @@ def test_simulate(xes):
         data=xes.data.copy())
 
     events = lf.simulate()
-    events = lf.simulate(rate_multipliers=dict('er_rate_multiplier'=2.)
+    events = lf.simulate(rate_multipliers=dict('er_rate_multiplier'=2.))
     events = lf.simulate(fix_truth=dict(x=0., y=0., z=-50.))
 
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -129,7 +129,7 @@ def test_simulate(xes):
         data=xes.data.copy())
 
     events = lf.simulate()
-    events = lf.simulate(rate_multipliers=dict('er_rate_multiplier'=2.))
+    events = lf.simulate(rate_multipliers=dict(er_rate_multiplier=2.))
     events = lf.simulate(fix_truth=dict(x=0., y=0., z=-50.))
 
 


### PR DESCRIPTION
This adds a simulate method to `LogLikelihood`, solving issue #16.

Simulate computes the mean number of events to simulate from each source in the likelihood by multiplying `mu(params)` with the rate multiplier. The rate multiplier can be specified in the `rate_multipliers` dict, otherwise the rate is determined via `_get_rate_mult`.
Optionally `fix_truth` is passed to the source simulator as well.
After simulating events from each source the DataFrames are concatenated and shuffled.

@JelleAalbers Do we need to add livetime as well? I saw that this is how its done in blueice but it's simply another multiplier on mu so can be put in the rate multiplier as well, any thoughts?