### PR TITLE
Revert default to bfgs, add minuit stepsize

### DIFF
--- a/notebooks/Tutorial.ipynb
+++ b/notebooks/Tutorial.ipynb
@@ -1,890 +1,888 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.9"
-    },
-    "colab": {
-      "name": "Tutorial.ipynb",
-      "provenance": []
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "XXFO1BJFVc0U"
+   },
+   "source": [
+    "# Flamedisx tutorial"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "mn5kKmUYVnU1",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "### Install flamedisx using pip\n",
-        "#!pip install flamedisx\n",
-        "\n",
-        "### In case you want to develop Flamedisx you can clone the repository\n",
-        "#!git clone https://github.com/FlamTeam/flamedisx.git\n",
-        "\n",
-        "# Install flamedisx\n",
-        "#%cd flamedisx\n",
-        "#!git checkout master\n",
-        "#!git pull origin master\n",
-        "#!python setup.py develop\n",
-        "#%cd .."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-bt_Wh_9WCCZ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Install Tensorflow\n",
-        "# Install TF2 and TFP w GPU support (change runtime to GPU to test)\n",
-        "#!pip install -U tensorflow-gpu==2.0.0\n",
-        "#!pip install -U tensorflow_probability==0.8.0\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "oIO18-VkVc0H",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import numpy as np\n",
-        "import matplotlib\n",
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "import flamedisx as fd\n",
-        "import tensorflow as tf"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XXFO1BJFVc0U",
-        "colab_type": "text"
-      },
-      "source": [
-        "# Flamedisx tutorial"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2Xr7X8UGVc0Z",
-        "colab_type": "text"
-      },
-      "source": [
-        "Flamedisx is a package for inference on Liquid Xenon TPC data. This tutorial assumes you are familiar with these detectors, and we will not attempt to explain jargon like S1, S2, etc."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VDXnTBSHVc0a",
-        "colab_type": "text"
-      },
-      "source": [
-        "## 1. Simulation"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RXejwWUQVc0d",
-        "colab_type": "text"
-      },
-      "source": [
-        "Before we can do anything, we have to load some data. If you don't have a LXe TPC handy, flamedisx can simulate some data for you."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "qfnwRt5bVc0h",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "df = fd.ERSource().simulate(1000)\n",
-        "df.head()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "GmacK6H8Vc0p",
-        "colab_type": "text"
-      },
-      "source": [
-        "Here we used the default `ERSource`, which describes a flat-spectrum ER source (with some cutoffs) homogeneously distributed in the TPC. \n",
-        "\n",
-        "Flamedisx has other `Source` classes for different populations. You usually want to define your own `Source`s. We'll discuss this later below.\n",
-        "\n",
-        "As you can see, the data is a Pandas dataframe. The first columns are direct observables, such as the $x$ position in cm and the $s1$ size in PE. The other columns are derived observables and truth info from the flamedisx simulator, which we can ignore for now.\n",
-        "\n",
-        "Let's plot the data:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "hG0728A4Vc0s",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def scatter_2x2d(df, s=10, color_by=None, color_label=None, vmin=None, vmax=None, **kwargs):\n",
-        "    f, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
-        "    \n",
-        "    if color_by is None:\n",
-        "        c = df['z']\n",
-        "        vmin, vmax = -100, 0\n",
-        "    else:\n",
-        "        c = color_by\n",
-        "        \n",
-        "    plt.sca(axes[0])\n",
-        "    plt.scatter(df['s1'], df['s2'], s=s, c=c, vmin=vmin, vmax=vmax, **kwargs)\n",
-        "    plt.colorbar(label='Z [cm]' if color_by is None else color_label)\n",
-        "    plt.xlim(0, 70)\n",
-        "    plt.ylim(0, None)\n",
-        "    plt.xlabel(\"S1 [PE]\")\n",
-        "    plt.ylabel(\"S2 [PE]\")\n",
-        "\n",
-        "    if color_by is None:\n",
-        "        c = df['s2']\n",
-        "        vmin, vmax = 0, 5500\n",
-        "    else:\n",
-        "        c = color_by\n",
-        "        \n",
-        "    plt.sca(axes[1])\n",
-        "    plt.scatter(df['r'], df['z'], c=c, s=s, vmin=vmin, vmax=vmax, **kwargs)\n",
-        "    plt.colorbar(label='S2 [PE]' if color_by is None else color_label)\n",
-        "    plt.xlabel(\"R [cm]\")\n",
-        "    plt.xlim(0, 50)\n",
-        "    plt.ylim(-100, 0)\n",
-        "\n",
-        "    plt.tight_layout()\n",
-        "    \n",
-        "scatter_2x2d(df)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jICAX-6pVc0y",
-        "colab_type": "text"
-      },
-      "source": [
-        "We asked flamedisx for 1000 events, but we actually got back a few less:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "jVuH3nLnVc00",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "len(df)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8upPBpEyVc08",
-        "colab_type": "text"
-      },
-      "source": [
-        "This is because the `Source` includes models for some basic cuts. If you're curious, the default source cuts events with less than 3 photons detected, S1 outside [2, 70] PE, or S2 outside [200, 5000] PE.\n",
-        "\n",
-        "You can also simulate events at specific energies, e.g. at 5 keV:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "AJ8ZBnd1Vc1A",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "scatter_2x2d(\n",
-        "    fd.ERSource().simulate(1000, fix_truth=dict(energy=5.)))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uPL1bRNOVc1F",
-        "colab_type": "text"
-      },
-      "source": [
-        "Finally, you can use another dataset to draw the auxiliary observables from -- anything besides s1 and s2, i.e. x, y, z, drift time, and (for custom sources) other things you might like. For example, here we simulate events at the same position as the first event in df:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "IZsEk4ETVc1J",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "scatter_2x2d(\n",
-        "    fd.ERSource().simulate(1000, fix_truth=df[:1]))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "T67_3pS6Vc1R",
-        "colab_type": "text"
-      },
-      "source": [
-        "## 2. Inference"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "N40QeBAaVc1T",
-        "colab_type": "text"
-      },
-      "source": [
-        "For this tutorial, let's just fit something easy: the electron lifetime (elife). To ensure the fit goes fast even if you don't have a GPU available, we simulate just 25 events as the dataset. The 'true' elife used to generate this is 452 us. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "xbZ_a907Vc1U",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "smalld = fd.ERSource().simulate(250)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LsMmlMUXVc1d",
-        "colab_type": "text"
-      },
-      "source": [
-        "Flamedisx computes the **differential rate** at each event analytically:\n",
-        "\n",
-        "\\begin{equation}\n",
-        "\\mu \\times \\text{PDF}(\\mathrm{S1}, \\mathrm{S2}, x, y, z, \\ldots)\n",
-        "\\end{equation}\n",
-        "\n",
-        "where $\\mu$ is the total expected number of events from the source.\n",
-        "\n",
-        "You rarely need to do this yourself, but let's do it anyway, for two electron lifetimes:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "scrolled": false,
-        "id": "sslhhgyKVc1g",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "source = fd.ERSource(smalld)\n",
-        "\n",
-        "for elife_us in (100, 500):\n",
-        "    diffrate = source.batched_differential_rate(elife=elife_us * 1e3)\n",
-        "    print(\"Electron lifetime = %d us\" % elife_us)\n",
-        "    scatter_2x2d(smalld, color_by=diffrate, color_label='Differential rate', cmap=plt.cm.jet)\n",
-        "    plt.show()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZFWuOftZVc1q",
-        "colab_type": "text"
-      },
-      "source": [
-        "Notice the differential rates are very low for elife = 100 us. Flamedisx correctly computed that all the events would  have to be extreme outliers if elife = 100 us were true. At 500 us, the rates are clearly higher, indicating the events wouldn't be so unusual at this elife."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eguL8uLVVc1s",
-        "colab_type": "text"
-      },
-      "source": [
-        "Looking directly at differential rates is  no way to do inference, you want an extended unbinned log likelihood to do this for you. For a single source, the formula is:\n",
-        "\\begin{equation}\n",
-        "\\log L = - \\mu + \\sum_\\mathrm{events} \\mu \\times \\text{PDF at the event}\n",
-        "\\end{equation}\n",
-        "where $\\mu$ is the expected number of events from the source (after all selections). The term inside the sum is the differential rate, which we've already seen that flamedisx can compute. For the first term $\\mu$, it still needs simulations at some \" anchor points\" -- reference parameter space values between it interpolates.\n",
-        "\n",
-        "Flamedisx likelihoods are made with the `LogLikelihood` class:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TIwijXKHVc1u",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "ll = fd.LogLikelihood(\n",
-        "    # Dictionary of sources to use. \n",
-        "    # Use multiple sources if your signal/background model has more than one component\n",
-        "    sources=dict(er=fd.ERSource),\n",
-        "    # Data to use:\n",
-        "    data=smalld,\n",
-        "    # Parameters to fit, with (lower anchor, upper anchor, number of anchor points):\n",
-        "    elife=(300e3, 500e3, 3),\n",
-        "    # Allow the absolute ER rate to be fitted as well\n",
-        "    free_rates=('er',))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tYkctMyjVc12",
-        "colab_type": "text"
-      },
-      "source": [
-        "You can get the best fit with the `bestfit`. Guesses are passed with the `guess` argument. To convert the bestfit to human-readable form, pass it to summary.\n",
-        "\n",
-        "It's a good idea to pass decent guesses. If you don't pass any guesses, well, it will just guess something, depending on the defaults specified in the source. These might be bad and cause the optimizer to fail.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "scrolled": false,
-        "id": "WHrgNduLVc2q",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "%%time\n",
-        "bestfit = ll.bestfit(guess=dict(er_rate_multiplier=0.03, elife=410e3))\n",
-        "ll.summary(bestfit[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vh_2ky9MVc21",
-        "colab_type": "text"
-      },
-      "source": [
-        "The best-fit value depends on the simulated data, which varies each time you run the notebook. However, it should be within +- 10 us of the true value, 452 us. This looks pretty amazing for just 50 events, but of course the ER model is here assumed completely known in all other respects, which is unrealistic.\n",
-        "\n",
-        "The errors and covariances are computed from the inverse of the Hessian (matrix of second derivatives). These are like the HESSE errors from migrad. You can get the inverse hessian yourself if you want:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "kufPgna7Vc23",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "inv_h = ll.inverse_hessian(bestfit[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TOT2mWrrVc2-",
-        "colab_type": "text"
-      },
-      "source": [
-        "If you already computed the Hessian, you can pass it to `summary` so it doesn't have to do it again. It will run almost instantly in that case."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "jJY7oftMVc3F",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "ll.summary(bestfit[0], inverse_hessian=inv_h)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hN5xBosLVc3K",
-        "colab_type": "text"
-      },
-      "source": [
-        "## 3. Modelling"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZEVlokihVc3L",
-        "colab_type": "text"
-      },
-      "source": [
-        "To do any serious work, you have to define custom sources. This means defining a class which inherits from one of the basic two flamedisx sources (ERSource or NRSource) and overrides one or more of the **model functions**. Here is the complete list of things you can override:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TvqPTgkiVc3Q",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "sorted(fd.er_nr_base.data_methods)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gtQ_zfcoVc3U",
-        "colab_type": "text"
-      },
-      "source": [
-        "Each of these can be specified as either a constant or a function. The function can take any **observable** (such as x or drift_time) as a positional argument and any **parameters** (something you can fit, e.g. elife) as keyword arguments.\n",
-        "\n",
-        "Here's an example: a source that parametrizes the loss of electrons during drift via the electron **absorption_length** (in cm) rather than elife:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "mxpBGj5uVc3V",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "class CustomERSource(fd.ERSource):\n",
-        "    \n",
-        "    # staticmethod just means: don't take self as an argument\n",
-        "    @staticmethod   \n",
-        "    def electron_detection_eff(z, absorption_length=60):\n",
-        "        # Note z is negative, and in cm\n",
-        "        return tf.exp(z / absorption_length)     \n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gGyMrg0tVc3e",
-        "colab_type": "text"
-      },
-      "source": [
-        "Note that we have to use tensorflow inside the model functions. If you keep it (very) simple, you can just replace np -> tf. Or, of course, you can learn tensorflow.\n",
-        "\n",
-        "We can fit this as before:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "cimI_dfDVc3g",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "ll2 = fd.LogLikelihood(\n",
-        "    sources=dict(er=CustomERSource),\n",
-        "    data=smalld,\n",
-        "    absorption_length=(20., 100., 3),\n",
-        "    free_rates=('er',))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "gD2hgd4vVc3n",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "%%time\n",
-        "bf2 = ll2.bestfit(guess=dict(er_rate_multiplier=0.014, absorption_length=66.))\n",
-        "ll2.summary(bf2[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "N5H1b4VQVc3s",
-        "colab_type": "text"
-      },
-      "source": [
-        "The result will be around 60 cm (+- 1.5 cm or so), which is the true value consistent with our our 452 us elife:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "pudeTjBPVc3u",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "452e3 * fd.ERSource.drift_velocity"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "z42sMMWUVc3x",
-        "colab_type": "text"
-      },
-      "source": [
-        "## 4. Modelling 2"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qeoormmrVc3y",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's try to fit a more complex part of the ER model. In particular, let's find `p_electron`, the **fraction of detected quanta that are electrons** as a function of energy. This is equivalent to the charge yield Q_y (given a work function), and encodes all effects of exciton/ion splitting and recombination.\n",
-        "\n",
-        "Here's a source implementation that achieves this:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "gYuJKGdDVc3z",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "class MyERSource(fd.ERSource):\n",
-        "\n",
-        "    @staticmethod\n",
-        "    #def p_electron(nq, a=0.2, b=-0.38, c=0.45, nq0=365):\n",
-        "    def p_electron(nq, a=0.1, b=-0.25, c=0.40, nq0=365.):\n",
-        "        x = fd.tf_log10(nq / nq0 + 1e-9)\n",
-        "        x = tf.dtypes.cast(x, dtype=fd.float_type())\n",
-        "        return fd.safe_p(a * x * x + b * x + c)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tVJr4u2UVc32",
-        "colab_type": "text"
-      },
-      "source": [
-        "Note:\n",
-        "  * The `p_electron` takes an additional argument `nq`, the number of produced quanta. This is not an observable, but a 'hidden variable' of the process, just like e.g. energy or the number of produced photons. In flamedisx you have complete freedom to make any model function depend on any observable you like, but you cannot add dependencies on hidden variables. Such changes would require changes in the flamedisx core code.\n",
-        "  * fd.tf_log10 is a shortcut to tensorflow implementation of log10 (the base-10 logarithm)\n",
-        "  * fd.safe_p clips the values to just above 0 and just below 1.\n",
-        "  \n",
-        "Let's fit it, along with a few other parameters that could be a cause for uncertainty such as elife and g2:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ohat_bsYVc33",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "ll3 = fd.LogLikelihood(\n",
-        "    sources=dict(er=MyERSource),\n",
-        "    data=smalld,\n",
-        "    a=(0.1, 0.5, 3),\n",
-        "    b=(-0.5, -0.2, 3),\n",
-        "    c=(0.35, 0.45, 3),\n",
-        "    elife=(400e3, 500e3, 3),\n",
-        "    g2=(25., 35., 3),\n",
-        "    free_rates=('er',))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SXaGWoS-Vc3-",
-        "colab_type": "text"
-      },
-      "source": [
-        "Notice the mu estimation took a bit longer, because we have more parameters to fit. However, this scales linearly with the number of parameters and anchor points. This is because we assume the effects of each parameter (except the rate multipliers) on $\\mu$ are small, so we can add them linearly. For most parameters this is quite accurate, especially if you have a decent amount of data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "SD2MgO8dVc3_",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "%%time\n",
-        "bf3 = ll3.bestfit(guess=dict(er_rate_multiplier=0.012))\n",
-        "ll3.summary(bf3[0])"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "v9BcPTxDVc4C",
-        "colab_type": "text"
-      },
-      "source": [
-        "The fit took ~4x as long, because it had a bigger parameter space to explore -- 6D vs. 2D. Things could have been much, much worse. As our likelihood is differentiable, we could give the minimizer a gradient. This told it in which direction to go -- quite useful if you are lost in six dimensions!\n",
-        "\n",
-        "Finally, let's compare the p_electron function we ust fitted with the ground truth -- that is, the ones the data was simulated with:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "wMBkYqAeVc4E",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def plot_nq(s_class=fd.ERSource, plot_kwargs=None, twin=True, \n",
-        "            # Eat params we don't need...\n",
-        "            er_rate_multiplier=None, elife=None, g2=None,\n",
-        "            **params):\n",
-        "    if plot_kwargs is None:\n",
-        "        plot_kwargs = dict()\n",
-        "    nq = np.logspace(1, 4, 100)\n",
-        "    \n",
-        "    plt.plot(nq, s_class.p_electron(nq, **params), **plot_kwargs)\n",
-        "    plt.xlabel('Produced quanta')\n",
-        "    plt.ylabel('p_electron')\n",
-        "    plt.xlim(10, 1e4)\n",
-        "    plt.xscale('log')\n",
-        "    ax = plt.gca()\n",
-        "    \n",
-        "    if twin:\n",
-        "        ax2 = plt.twiny()\n",
-        "        ax2.set_xscale('log')\n",
-        "        ax2.set_xlim(*np.array(ax.get_xlim()) * fd.ERSource.work)\n",
-        "        ax2.set_xlabel(\"Energy [keV]\")\n",
-        "\n",
-        "    for x in [ax] + ([ax2] if twin else []):\n",
-        "        x.xaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
-        "    plt.sca(ax)\n",
-        "        \n",
-        "plot_nq(plot_kwargs=dict(label='Truth'))\n",
-        "plot_nq(MyERSource,  plot_kwargs=dict(label='Guess'), twin=False)\n",
-        "plot_nq(MyERSource,  plot_kwargs=dict(label='Fit'), twin=False, **bf3[0])\n",
-        "plt.legend(loc='upper right')"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5xa8g3tLVc4G",
-        "colab_type": "text"
-      },
-      "source": [
-        "It seems we actually fitted something! The fit is poor at high energy, because or data does not reach so far."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wuIbbWuhVc4M",
-        "colab_type": "text"
-      },
-      "source": [
-        "## 5. Why bother with high-dimensional likelihoods?"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "taaxp1F7Vc4O",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's draw some mock ER data with a poor electron lifetime of 200 us -- you'll see why in a moment. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "LJv9hCrkVc4P",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "df = fd.ERSource().simulate(5000, elife=200e3)\n",
-        "scatter_2x2d(df)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TaqE3pyxVc4R",
-        "colab_type": "text"
-      },
-      "source": [
-        "You can see the mean S2 decreases with z, due to the finite electron lifetime in the TPC. Usually, experiments correct for the mean position dependence of their observables. We can define the detector-independent quantities: \n",
-        "\n",
-        "\\begin{array}\n",
-        ".E_\\mathrm{light} &= W \\big(\\mathrm{S1} / g_1(x,y,z) \\big) \\\\\n",
-        "E_{\\mathrm{charge}} &= W \\big(\\mathrm{S2} / g_2(x,y,z) \\big) \\\\\n",
-        "\\end{array}\n",
-        "\n",
-        "with W the liquid xenon work function, and g1 and g2 the detector response per produced photon/electron at the observed (x,y) position.Plotting these, you can see most of the position dependence is gone:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "BRqIn8ofVc4S",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def scatter_energy(df, s=3, cbar=True, **kwargs):\n",
-        "    plt.scatter(df['e_light_vis'], df['e_charge_vis'], \n",
-        "                c=df['z'], vmin=-100, vmax=0,\n",
-        "                s=s)\n",
-        "    plt.xlabel(r\"$E_\\mathrm{light}$ [$\\mathrm{keV}_\\mathrm{ee}$]\")\n",
-        "    plt.xlim(0, 8)\n",
-        "    plt.ylabel(r\"$E_\\mathrm{charge}$ [$\\mathrm{keV}_\\mathrm{ee}$]\")\n",
-        "    plt.ylim(0, 6)\n",
-        "    plt.gca().set_aspect('equal')\n",
-        "    if cbar:\n",
-        "        plt.colorbar(label='Z [cm]', **kwargs)\n",
-        "    \n",
-        "scatter_energy(df)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SxWmzG6IVc4V",
-        "colab_type": "text"
-      },
-      "source": [
-        "However, there is still a $z$-dependent effect: the fluctuation in E_charge is much larger in the bottom of the TPC than the bottom. You can see this more clearly if we split out the different z's:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Z_Bk49RSVc4W",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "f, axes = plt.subplots(1, 3, figsize=(14, 3.5), sharey=True)\n",
-        "plt.subplots_adjust(wspace=0)\n",
-        "for i, z_slice in enumerate([(-90, -60), (-60, -30), (-30, 0)]):\n",
-        "    plt.sca(axes[i])\n",
-        "    scatter_energy(df[(z_slice[0] < df['z']) & (df['z'] < z_slice[1])],\n",
-        "                   cbar=i == 2, ax=axes)\n",
-        "    plt.title(\"%d < Z [cm] < %d\" % z_slice)\n",
-        "    if i != 0:\n",
-        "        plt.ylabel(\"\")\n",
-        "    if i != 2:\n",
-        "        plt.xticks(plt.xticks()[0][:-1])\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "s1xg7wvWVc4a",
-        "colab_type": "text"
-      },
-      "source": [
-        "The cause is simply a statistical effect: because the S2s in the bottom of the smaller, E_charge has a larger relative fluctuation. This means ER/NR discrimination at the bottom of the TPC will be worse than at the top.\n",
-        "\n",
-        "The g1/g2 correction accounts for the mean position-dependence, but still loses information. This is one of the reasons that higher-dimensional likelihoods can provide a gain in sensitivity."
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "2Xr7X8UGVc0Z"
+   },
+   "source": [
+    "Flamedisx is a package for inference on Liquid Xenon TPC data. This tutorial assumes you are familiar with these detectors, and we will not attempt to explain jargon like S1, S2, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run this notebook, you have two options:\n",
+    "\n",
+    "  1) Install flamedisx locally with `pip install flamedisx` in a fresh environment. This should install all necessary dependencies (in particular, tensorflow 2). \n",
+    "    \n",
+    "  2) Use Google's colaboratory, so you do not have to install anything and can use a GPU. Follow the steps below: \n",
+    "  \n",
+    "  * Open the notebook in colab using https://colab.research.google.com/github/FlamTeam/flamedisx/blob/master/notebooks/Tutorial.ipynb.\n",
+    "  * Uncomment and run the cell below\n",
+    "  * Restart the runtime (either with the button that will appear, or use Runtime -> Restart runtime.\n",
+    "  * Run the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "mn5kKmUYVnU1"
+   },
+   "outputs": [],
+   "source": [
+    "# # Setup for Google colaboratory\n",
+    "# !pip install flamedisx\n",
+    "# !pip install -U tensorflow-gpu==2.0.0\n",
+    "# !pip install -U tensorflow_probability==0.8.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "oIO18-VkVc0H"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import flamedisx as fd\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "VDXnTBSHVc0a"
+   },
+   "source": [
+    "## 1. Simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "RXejwWUQVc0d"
+   },
+   "source": [
+    "Before we can do anything, we have to load some data. If you don't have a LXe TPC handy, flamedisx can simulate some data for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qfnwRt5bVc0h"
+   },
+   "outputs": [],
+   "source": [
+    "df = fd.ERSource().simulate(1000)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "GmacK6H8Vc0p"
+   },
+   "source": [
+    "Here we used the default `ERSource`, which describes a flat-spectrum ER source (with some cutoffs) homogeneously distributed in the TPC. \n",
+    "\n",
+    "Flamedisx has other `Source` classes for different populations. You usually want to define your own `Source`s. We'll discuss this later below.\n",
+    "\n",
+    "As you can see, the data is a Pandas dataframe. The first columns are direct observables, such as the $x$ position in cm and the $s1$ size in PE. The other columns are derived observables and truth info from the flamedisx simulator, which we can ignore for now.\n",
+    "\n",
+    "Let's plot the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "hG0728A4Vc0s"
+   },
+   "outputs": [],
+   "source": [
+    "def scatter_2x2d(df, s=10, color_by=None, color_label=None, vmin=None, vmax=None, **kwargs):\n",
+    "    f, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "    \n",
+    "    if color_by is None:\n",
+    "        c = df['z']\n",
+    "        vmin, vmax = -100, 0\n",
+    "    else:\n",
+    "        c = color_by\n",
+    "        \n",
+    "    plt.sca(axes[0])\n",
+    "    plt.scatter(df['s1'], df['s2'], s=s, c=c, vmin=vmin, vmax=vmax, **kwargs)\n",
+    "    plt.colorbar(label='Z [cm]' if color_by is None else color_label)\n",
+    "    plt.xlim(0, 70)\n",
+    "    plt.ylim(0, None)\n",
+    "    plt.xlabel(\"S1 [PE]\")\n",
+    "    plt.ylabel(\"S2 [PE]\")\n",
+    "\n",
+    "    if color_by is None:\n",
+    "        c = df['s2']\n",
+    "        vmin, vmax = 0, 5500\n",
+    "    else:\n",
+    "        c = color_by\n",
+    "        \n",
+    "    plt.sca(axes[1])\n",
+    "    plt.scatter(df['r'], df['z'], c=c, s=s, vmin=vmin, vmax=vmax, **kwargs)\n",
+    "    plt.colorbar(label='S2 [PE]' if color_by is None else color_label)\n",
+    "    plt.xlabel(\"R [cm]\")\n",
+    "    plt.xlim(0, 50)\n",
+    "    plt.ylim(-100, 0)\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    \n",
+    "scatter_2x2d(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jICAX-6pVc0y"
+   },
+   "source": [
+    "We asked flamedisx for 1000 events, but we actually got back a few less:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "jVuH3nLnVc00"
+   },
+   "outputs": [],
+   "source": [
+    "len(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "8upPBpEyVc08"
+   },
+   "source": [
+    "This is because the `Source` includes models for some basic cuts. If you're curious, the default source cuts events with less than 3 photons detected, S1 outside [2, 70] PE, or S2 outside [200, 5000] PE.\n",
+    "\n",
+    "You can also simulate events at specific energies, e.g. at 5 keV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "AJ8ZBnd1Vc1A"
+   },
+   "outputs": [],
+   "source": [
+    "scatter_2x2d(\n",
+    "    fd.ERSource().simulate(1000, fix_truth=dict(energy=5.)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "uPL1bRNOVc1F"
+   },
+   "source": [
+    "Finally, you can use another dataset to draw the auxiliary observables from -- anything besides s1 and s2, i.e. x, y, z, drift time, and (for custom sources) other things you might like. For example, here we simulate events at the same position as the first event in df:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "IZsEk4ETVc1J"
+   },
+   "outputs": [],
+   "source": [
+    "scatter_2x2d(\n",
+    "    fd.ERSource().simulate(1000, fix_truth=df[:1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "T67_3pS6Vc1R"
+   },
+   "source": [
+    "## 2. Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "N40QeBAaVc1T"
+   },
+   "source": [
+    "For this tutorial, let's just fit something easy: the electron lifetime (elife). To ensure the fit goes fast even if you don't have a GPU available, we simulate just 25 events as the dataset. The 'true' elife used to generate this is 452 us. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "xbZ_a907Vc1U"
+   },
+   "outputs": [],
+   "source": [
+    "smalld = fd.ERSource().simulate(25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LsMmlMUXVc1d"
+   },
+   "source": [
+    "Flamedisx computes the **differential rate** at each event analytically:\n",
+    "\n",
+    "\\begin{equation}\n",
+    "\\mu \\times \\text{PDF}(\\mathrm{S1}, \\mathrm{S2}, x, y, z, \\ldots)\n",
+    "\\end{equation}\n",
+    "\n",
+    "where $\\mu$ is the total expected number of events from the source.\n",
+    "\n",
+    "You rarely need to do this yourself, but let's do it anyway, for two electron lifetimes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sslhhgyKVc1g"
+   },
+   "outputs": [],
+   "source": [
+    "source = fd.ERSource(smalld)\n",
+    "\n",
+    "for elife_us in (100, 500):\n",
+    "    diffrate = source.batched_differential_rate(elife=elife_us * 1e3)\n",
+    "    print(\"Electron lifetime = %d us\" % elife_us)\n",
+    "    scatter_2x2d(smalld, color_by=diffrate, color_label='Differential rate', cmap=plt.cm.jet)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZFWuOftZVc1q"
+   },
+   "source": [
+    "Notice the differential rates are very low for elife = 100 us. Flamedisx correctly computed that all the events would  have to be extreme outliers if elife = 100 us were true. At 500 us, the rates are clearly higher, indicating the events wouldn't be so unusual at this elife."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "eguL8uLVVc1s"
+   },
+   "source": [
+    "Looking directly at differential rates is  no way to do inference, you want an extended unbinned log likelihood to do this for you. For a single source, the formula is:\n",
+    "\\begin{equation}\n",
+    "\\log L = - \\mu + \\sum_\\mathrm{events} \\mu \\times \\text{PDF at the event}\n",
+    "\\end{equation}\n",
+    "where $\\mu$ is the expected number of events from the source (after all selections). The term inside the sum is the differential rate, which we've already seen that flamedisx can compute. For the first term $\\mu$, it still needs simulations at some \" anchor points\" -- reference parameter space values between it interpolates.\n",
+    "\n",
+    "Flamedisx likelihoods are made with the `LogLikelihood` class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "TIwijXKHVc1u"
+   },
+   "outputs": [],
+   "source": [
+    "ll = fd.LogLikelihood(\n",
+    "    # Dictionary of sources to use. \n",
+    "    # Use multiple sources if your signal/background model has more than one component\n",
+    "    sources=dict(er=fd.ERSource),\n",
+    "    # Data to use:\n",
+    "    data=smalld,\n",
+    "    # Parameters to fit, with (lower anchor, upper anchor, number of anchor points):\n",
+    "    elife=(300e3, 500e3, 3),\n",
+    "    # Allow the absolute ER rate to be fitted as well\n",
+    "    free_rates=('er',))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "tYkctMyjVc12"
+   },
+   "source": [
+    "You can get the best fit with the `bestfit`. Guesses are passed with the `guess` argument. To convert the bestfit to human-readable form, pass it to summary.\n",
+    "\n",
+    "It's a good idea to pass decent guesses. If you don't pass any guesses, well, it will just guess something, depending on the defaults specified in the source. These might be bad and cause the optimizer to fail.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "WHrgNduLVc2q"
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bestfit = ll.bestfit(guess=dict(er_rate_multiplier=0.03, elife=410e3))\n",
+    "ll.summary(bestfit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vh_2ky9MVc21"
+   },
+   "source": [
+    "The best-fit value depends on the simulated data, which varies each time you run the notebook. Most of the time, it should be within +- 10 us of the true value, 452 us. This seems pretty amazing for just 50 events, but of course the ER model is here assumed completely known in all other respects, which is unrealistic.\n",
+    "\n",
+    "The errors and covariances are computed from the inverse of the Hessian (matrix of second derivatives). These are like the HESSE errors from migrad. You can get the inverse hessian yourself if you want:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "kufPgna7Vc23"
+   },
+   "outputs": [],
+   "source": [
+    "inv_h = ll.inverse_hessian(bestfit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "TOT2mWrrVc2-"
+   },
+   "source": [
+    "If you already computed the Hessian, you can pass it to `summary` so it doesn't have to do it again. It will run almost instantly in that case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "jJY7oftMVc3F"
+   },
+   "outputs": [],
+   "source": [
+    "ll.summary(bestfit, inverse_hessian=inv_h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hN5xBosLVc3K"
+   },
+   "source": [
+    "## 3. Modelling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZEVlokihVc3L"
+   },
+   "source": [
+    "To do any serious work, you have to define custom sources. This means defining a class which inherits from one of the basic two flamedisx sources (ERSource or NRSource) and overrides one or more of the **model functions**. Here is the complete list of things you can override:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "TvqPTgkiVc3Q"
+   },
+   "outputs": [],
+   "source": [
+    "sorted(fd.er_nr_base.data_methods)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gtQ_zfcoVc3U"
+   },
+   "source": [
+    "Each of these can be specified as either a constant or a function. The function can take any **observable** (such as x or drift_time) as a positional argument and any **parameters** (something you can fit, e.g. elife) as keyword arguments.\n",
+    "\n",
+    "Here's an example: a source that parametrizes the loss of electrons during drift via the electron **absorption_length** (in cm) rather than elife:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "mxpBGj5uVc3V"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "class CustomERSource(fd.ERSource):\n",
+    "    \n",
+    "    # staticmethod just means: don't take self as an argument\n",
+    "    @staticmethod   \n",
+    "    def electron_detection_eff(z, absorption_length=60):\n",
+    "        # Note z is negative, and in cm\n",
+    "        return tf.exp(z / absorption_length)     \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gGyMrg0tVc3e"
+   },
+   "source": [
+    "Note that we have to use tensorflow inside the model functions. If you keep it (very) simple, you can just replace np -> tf. Or, of course, you can learn tensorflow.\n",
+    "\n",
+    "We can fit this as before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "cimI_dfDVc3g"
+   },
+   "outputs": [],
+   "source": [
+    "ll2 = fd.LogLikelihood(\n",
+    "    sources=dict(er=CustomERSource),\n",
+    "    data=smalld,\n",
+    "    absorption_length=(20., 100., 3),\n",
+    "    free_rates=('er',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "gD2hgd4vVc3n"
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bf2 = ll2.bestfit(guess=dict(er_rate_multiplier=0.014, absorption_length=66.))\n",
+    "ll2.summary(bf2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "N5H1b4VQVc3s"
+   },
+   "source": [
+    "The result will usually be around 60 cm (+- 1.5 cm or so), which is the true value consistent with our our 452 us elife:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "pudeTjBPVc3u"
+   },
+   "outputs": [],
+   "source": [
+    "452e3 * fd.ERSource.drift_velocity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "z42sMMWUVc3x"
+   },
+   "source": [
+    "## 4. Modelling 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "qeoormmrVc3y"
+   },
+   "source": [
+    "Let's try to fit a more complex part of the ER model. In particular, let's find `p_electron`, the **fraction of detected quanta that are electrons** as a function of energy. This is equivalent to the charge yield Q_y (given a work function), and encodes all effects of exciton/ion splitting and recombination.\n",
+    "\n",
+    "Here's a source implementation that achieves this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "gYuJKGdDVc3z"
+   },
+   "outputs": [],
+   "source": [
+    "class MyERSource(fd.ERSource):\n",
+    "\n",
+    "    @staticmethod\n",
+    "    #def p_electron(nq, a=0.2, b=-0.38, c=0.45, nq0=365):\n",
+    "    def p_electron(nq, a=0.1, b=-0.25, c=0.40, nq0=365.):\n",
+    "        x = fd.tf_log10(nq / nq0 + 1e-9)\n",
+    "        x = tf.dtypes.cast(x, dtype=fd.float_type())\n",
+    "        return fd.safe_p(a * x * x + b * x + c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "tVJr4u2UVc32"
+   },
+   "source": [
+    "Note:\n",
+    "  * The `p_electron` takes an additional argument `nq`, the number of produced quanta. This is not an observable, but a 'hidden variable' of the process, just like e.g. energy or the number of produced photons. In flamedisx you have complete freedom to make any model function depend on any observable you like, but you cannot add dependencies on hidden variables. Such changes would require changes in the flamedisx core code.\n",
+    "  * fd.tf_log10 is a shortcut to tensorflow implementation of log10 (the base-10 logarithm)\n",
+    "  * fd.safe_p clips the values to just above 0 and just below 1.\n",
+    "  \n",
+    "Let's fit it, along with a few other parameters that could be a cause for uncertainty such as elife and g2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "ohat_bsYVc33"
+   },
+   "outputs": [],
+   "source": [
+    "ll3 = fd.LogLikelihood(\n",
+    "    sources=dict(er=MyERSource),\n",
+    "    data=smalld,\n",
+    "    a=(0.1, 0.5, 3),\n",
+    "    b=(-0.5, -0.2, 3),\n",
+    "    c=(0.35, 0.45, 3),\n",
+    "    elife=(400e3, 500e3, 3),\n",
+    "    g2=(25., 35., 3),\n",
+    "    free_rates=('er',))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "SXaGWoS-Vc3-"
+   },
+   "source": [
+    "Notice the mu estimation took a bit longer, because we have more parameters to fit. However, this scales linearly with the number of parameters and anchor points. This is because we assume the effects of each parameter (except the rate multipliers) on $\\mu$ are small, so we can add them linearly. For most parameters this is quite accurate, especially if you have a decent amount of data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "SD2MgO8dVc3_"
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bf3 = ll3.bestfit(guess=dict(er_rate_multiplier=0.012))\n",
+    "ll3.summary(bf3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "v9BcPTxDVc4C"
+   },
+   "source": [
+    "The fit took ~4x as long, because it had a bigger parameter space to explore -- 6D vs. 2D. Things could have been much, much worse. As our likelihood is differentiable, we could give the minimizer a gradient. This told it in which direction to go -- quite useful if you are lost in six dimensions!\n",
+    "\n",
+    "Finally, let's compare the p_electron function we ust fitted with the ground truth -- that is, the ones the data was simulated with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "wMBkYqAeVc4E"
+   },
+   "outputs": [],
+   "source": [
+    "def plot_nq(s_class=fd.ERSource, plot_kwargs=None, twin=True, \n",
+    "            # Eat params we don't need...\n",
+    "            er_rate_multiplier=None, elife=None, g2=None,\n",
+    "            **params):\n",
+    "    if plot_kwargs is None:\n",
+    "        plot_kwargs = dict()\n",
+    "    nq = np.logspace(1, 4, 100)\n",
+    "    \n",
+    "    plt.plot(nq, s_class.p_electron(nq, **params), **plot_kwargs)\n",
+    "    plt.xlabel('Produced quanta')\n",
+    "    plt.ylabel('p_electron')\n",
+    "    plt.xlim(10, 1e4)\n",
+    "    plt.xscale('log')\n",
+    "    ax = plt.gca()\n",
+    "    \n",
+    "    if twin:\n",
+    "        ax2 = plt.twiny()\n",
+    "        ax2.set_xscale('log')\n",
+    "        ax2.set_xlim(*np.array(ax.get_xlim()) * fd.ERSource.work)\n",
+    "        ax2.set_xlabel(\"Energy [keV]\")\n",
+    "\n",
+    "    for x in [ax] + ([ax2] if twin else []):\n",
+    "        x.xaxis.set_major_formatter(matplotlib.ticker.ScalarFormatter())\n",
+    "    plt.sca(ax)\n",
+    "        \n",
+    "plot_nq(plot_kwargs=dict(label='Truth'))\n",
+    "plot_nq(MyERSource,  plot_kwargs=dict(label='Guess'), twin=False)\n",
+    "plot_nq(MyERSource,  plot_kwargs=dict(label='Fit'), twin=False, **bf3)\n",
+    "plt.legend(loc='upper right')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5xa8g3tLVc4G"
+   },
+   "source": [
+    "It seems we actually fitted something! The fit is poor at high energy, because or data does not reach so far."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wuIbbWuhVc4M"
+   },
+   "source": [
+    "## 5. Why bother with high-dimensional likelihoods?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "taaxp1F7Vc4O"
+   },
+   "source": [
+    "Let's draw some mock ER data with a poor electron lifetime of 200 us -- you'll see why in a moment. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "LJv9hCrkVc4P"
+   },
+   "outputs": [],
+   "source": [
+    "df = fd.ERSource().simulate(5000, elife=200e3)\n",
+    "scatter_2x2d(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "TaqE3pyxVc4R"
+   },
+   "source": [
+    "You can see the mean S2 decreases with z, due to the finite electron lifetime in the TPC. Usually, experiments correct for the mean position dependence of their observables. We can define the detector-independent quantities: \n",
+    "\n",
+    "\\begin{array}\n",
+    ".E_\\mathrm{light} &= W \\big(\\mathrm{S1} / g_1(x,y,z) \\big) \\\\\n",
+    "E_{\\mathrm{charge}} &= W \\big(\\mathrm{S2} / g_2(x,y,z) \\big) \\\\\n",
+    "\\end{array}\n",
+    "\n",
+    "with W the liquid xenon work function, and g1 and g2 the detector response per produced photon/electron at the observed (x,y) position.Plotting these, you can see most of the position dependence is gone:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "BRqIn8ofVc4S"
+   },
+   "outputs": [],
+   "source": [
+    "def scatter_energy(df, s=3, cbar=True, **kwargs):\n",
+    "    plt.scatter(df['e_light_vis'], df['e_charge_vis'], \n",
+    "                c=df['z'], vmin=-100, vmax=0,\n",
+    "                s=s)\n",
+    "    plt.xlabel(r\"$E_\\mathrm{light}$ [$\\mathrm{keV}_\\mathrm{ee}$]\")\n",
+    "    plt.xlim(0, 8)\n",
+    "    plt.ylabel(r\"$E_\\mathrm{charge}$ [$\\mathrm{keV}_\\mathrm{ee}$]\")\n",
+    "    plt.ylim(0, 6)\n",
+    "    plt.gca().set_aspect('equal')\n",
+    "    if cbar:\n",
+    "        plt.colorbar(label='Z [cm]', **kwargs)\n",
+    "    \n",
+    "scatter_energy(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "SxWmzG6IVc4V"
+   },
+   "source": [
+    "However, there is still a $z$-dependent effect: the fluctuation in E_charge is much larger in the bottom of the TPC than the bottom. You can see this more clearly if we split out the different z's:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Z_Bk49RSVc4W"
+   },
+   "outputs": [],
+   "source": [
+    "f, axes = plt.subplots(1, 3, figsize=(14, 3.5), sharey=True)\n",
+    "plt.subplots_adjust(wspace=0)\n",
+    "for i, z_slice in enumerate([(-90, -60), (-60, -30), (-30, 0)]):\n",
+    "    plt.sca(axes[i])\n",
+    "    scatter_energy(df[(z_slice[0] < df['z']) & (df['z'] < z_slice[1])],\n",
+    "                   cbar=i == 2, ax=axes)\n",
+    "    plt.title(\"%d < Z [cm] < %d\" % z_slice)\n",
+    "    if i != 0:\n",
+    "        plt.ylabel(\"\")\n",
+    "    if i != 2:\n",
+    "        plt.xticks(plt.xticks()[0][:-1])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "s1xg7wvWVc4a"
+   },
+   "source": [
+    "The cause is simply a statistical effect: because the S2s in the bottom of the smaller, E_charge has a larger relative fluctuation. This means ER/NR discrimination at the bottom of the TPC will be worse than at the top.\n",
+    "\n",
+    "The g1/g2 correction accounts for the mean position-dependence, but still loses information. This is one of the reasons that higher-dimensional likelihoods can provide a gain in sensitivity."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "Tutorial.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -287,10 +287,10 @@ def test_bestfit_tf(xes):
     guess['er_rate_multiplier'] = xs[np.argmin(ys)]
     assert len(guess) == 2
 
-    bestfit = lf.bestfit(guess, optimizer=tfp.optimizer.bfgs_minimize, use_hessian=True)
-    assert isinstance(bestfit[0], dict)
-    assert len(bestfit[0]) == 2
-    assert bestfit[0]['er_rate_multiplier'].dtype == np.float32
+    bestfit = lf.bestfit(guess, optimizer='bfgs', use_hessian=True)
+    assert isinstance(bestfit, dict)
+    assert len(bestfit) == 2
+    assert bestfit['er_rate_multiplier'].dtype == np.float32
 
 
 def test_bestfit_minuit(xes):
@@ -311,7 +311,8 @@ def test_bestfit_minuit(xes):
     guess['er_rate_multiplier'] = xs[np.argmin(ys)]
     assert len(guess) == 2
 
-    bestfit = lf.bestfit(guess, optimizer=Minuit.from_array_func, error = (0.0001,1000))
+    bestfit = lf.bestfit(guess, optimizer='minuit',
+                         return_errors=True,
+                         error=(0.0001, 1000))
     assert isinstance(bestfit[0], dict)
     assert len(bestfit[0]) == 2
-    


### PR DESCRIPTION
This:
  * Changes the default optimizer back to bfgs. For running the tutorial on a CPU, this means the fits complete in 5-10 seconds rather than a minute.
  * Add a default stepsize of 0.1 * the guess to the minuit parameters. If we don't do this we get a warning and it will use 1 as the stepsize, at least for the rate multiplier (for which this is very large)
  * Make bestfit just return the bestfit dictionary without errors as default, so we don't need to do [0] every time. You can get the error dict by passing return_errors=True if you are using minuit. Alternatively we can look into returning some kind of FitResult namedtuple, with .errors and .result as attributes.
  * Adds explicit colab instructions to the tutorial.