### PR TITLE
Different parameters to different sources in the initialisation of the likelihood

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -96,7 +96,7 @@ class LogLikelihood:
 
         # Determine default parameters for each source
         defaults_in_sources = {
-            sname : sclass.find_defaults()[2]
+            sname : sclass().find_defaults()[2]
             for sname, sclass in self.sources.items()}
 
         # Create sources. Have to copy data, it's modified by set_data

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -185,6 +185,8 @@ class LogLikelihood:
 
         ds = []
         for sname, s in self.sources.items():
+            # done to ignore ColumnSource.
+            # TODO: remove if when simulate for ColumnSource is implemented
             if s.defaults:
                 rmname = sname + '_rate_multiplier'
                 if rmname in rate_multipliers:

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -93,21 +93,19 @@ class LogLikelihood:
             if sn not in self.sources:
                 raise ValueError(f"Can't free rate of unknown source {sn}")
             param_defaults[sn + '_rate_multiplier'] = 1.
-        
-        sources_null_init = {
-            sname: sclass(data=None)
-            for sname, sclass in self.sources.items()}
+
+        # Determine default parameters for each source
         defaults_in_sources = {
-            sname : sclass.defaults
-            for sname, sclass in sources_null_init.items()}
-            
+            sname : sclass.find_defaults()[2]
+            for sname, sclass in self.sources.items()}
+
         # Create sources. Have to copy data, it's modified by set_data
         self.sources = {
             sname: sclass(data=(None
                                 if data[self.d_for_s[sname]] is None
                                 else data[self.d_for_s[sname]].copy()),
                           max_sigma=max_sigma,
-                          fit_params=list(k for k in common_param_specs.keys() 
+                          fit_params=list(k for k in common_param_specs.keys()
                                           if k in defaults_in_sources[sname].keys()),
                           batch_size=batch_size)
             for sname, sclass in self.sources.items()}

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -185,24 +185,26 @@ class LogLikelihood:
 
         ds = []
         for sname, s in self.sources.items():
-            rmname = sname + '_rate_multiplier'
-            if rmname in rate_multipliers:
-                rm = rate_multipliers[rmname]
-            else:
-                rm = self._get_rate_mult(sname, params)
+            if self.s.defaults:
+                rmname = sname + '_rate_multiplier'
+                if rmname in rate_multipliers:
+                    rm = rate_multipliers[rmname]
+                else:
+                  rm = self._get_rate_mult(sname, params)
 
-            # mean number of events to simulate, rate mult times mu source
-            mu = rm * self.mu_itps[sname](**self._filter_source_kwargs(params,
-                                                                       sname))
-            # Simulate this many events from source
-            n_to_sim = np.random.poisson(mu)
-            if n_to_sim == 0:
-                continue
-            d = s.simulate(n_to_sim,
-                           fix_truth=fix_truth,
-                           **params)
-            d['source'] = sname
-            ds.append(d)
+                # mean number of events to simulate, rate mult times mu source
+                mu = rm * self.mu_itps[sname](**self._filter_source_kwargs(params,
+                                                                           sname))
+                # Simulate this many events from source
+                n_to_sim = np.random.poisson(mu)
+                if n_to_sim == 0:
+                    continue
+                d = s.simulate(n_to_sim,
+                               fix_truth=fix_truth,
+                               **self._filter_source_kwargs(params,
+                                                            sname))
+                d['source'] = sname
+                ds.append(d)
         # Concatenate results and shuffle them
         return pd.concat(ds, sort=False).sample(frac=1).reset_index(drop=True)
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -96,7 +96,7 @@ class LogLikelihood:
 
         # Determine default parameters for each source
         defaults_in_sources = {
-            sname : sclass().find_defaults()[2]
+            sname : sclass.find_defaults()[2]
             for sname, sclass in self.sources.items()}
 
         # Create sources. Have to copy data, it's modified by set_data

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -185,7 +185,7 @@ class LogLikelihood:
 
         ds = []
         for sname, s in self.sources.items():
-            if self.s.defaults:
+            if s.defaults:
                 rmname = sname + '_rate_multiplier'
                 if rmname in rate_multipliers:
                     rm = rate_multipliers[rmname]

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -215,8 +215,6 @@ class Source(SourceBase):
             if k in self.defaults:
                 self.defaults[k] = tf.convert_to_tensor(
                     v, dtype=fd.float_type())
-            else:
-                raise ValueError(f"Key {k} not in defaults")
 
     def set_data(self,
                  data,

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -150,7 +150,7 @@ class Source(SourceBase):
         f_params = {x: [] for x in cls.data_methods}
         defaults = dict()
         for fname in cls.data_methods:
-            f = getattr(self, fname)
+            f = getattr(cls, fname)
             if not callable(f):
                 # Constant
                 continue

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -140,7 +140,7 @@ class Source(SourceBase):
     # Initialization and helpers
     ##
 
-    #@classmethod
+    @classmethod
     def find_defaults(cls):
         """Discover which functions need which arguments / dimensions
         Discover possible parameters.
@@ -154,14 +154,18 @@ class Source(SourceBase):
             if not callable(f):
                 # Constant
                 continue
-            for i, (pname, p) in enumerate(
-                    inspect.signature(f).parameters.items()):
+            seen_special = False
+            for pname, p in inspect.signature(f).parameters.items():
+                if pname == 'self':
+                    continue
                 if pname == 'i_batch':
                     # This function uses precomputed data
                     f_dims[fname].append(pname)
                     continue
                 if p.default is inspect.Parameter.empty:
-                    if not (fname in cls.special_data_methods and i == 0):
+                    if fname in cls.special_data_methods and not seen_special:
+                        seen_special = True
+                    else:
                         # It's an observable dimension
                         f_dims[fname].append(pname)
                 else:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -22,6 +22,17 @@ class SourceBase:
     n_padding = None
     trace_difrate = True
 
+    @classmethod
+    def find_defaults(cls):
+        """Discover which functions need which arguments / dimensions
+        Discover possible parameters.
+        Returns f_dims, f_params and defaults.
+
+        Overwritten by Source, SourceBase has no default f_dims,
+        f_params or defaults.
+        """
+        return dict(), dict(), dict()
+
     def _init_padding(self, batch_size, _skip_tf_init):
         # Annotate requests n_events, currently no padding
         self.n_padding = 0
@@ -100,7 +111,7 @@ class ColumnSource(SourceBase):
             self._init_padding(batch_size, _skip_tf_init)
             self.data_tensor = fd.np_to_tf(self.data[self.column])
             self.data_tensor = tf.reshape(self.data_tensor,
-                                          (-1,self.batch_size, 1))
+                                          (-1, self.batch_size, 1))
 
     def differential_rate(self, data_tensor, **params):
         return data_tensor[:, 0]

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -140,7 +140,7 @@ class Source(SourceBase):
     # Initialization and helpers
     ##
 
-    @classmethod
+    #@classmethod
     def find_defaults(cls):
         """Discover which functions need which arguments / dimensions
         Discover possible parameters.

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -111,7 +111,7 @@ class SR1ERSource(SR1Source,fd.ERSource):
                                 float('inf'))
     @staticmethod
     def s2_acceptance(s2):
-        return tf.where((s2 < 500) | (s2 > 6000),
+        return tf.where((s2 < 100) | (s2 > 6000),
                         tf.zeros_like(s2, dtype=fd.float_type()),
                         tf.ones_like(s2, dtype=fd.float_type()))
 


### PR DESCRIPTION
As stated in issue #50 I have come across a problem when trying to use different sources in the likelihood. If the different sources use different parameters the likelihood initialisation would fail since it was designed to use the same sets of parameters for all the sources. 
With this pull request I have changed the way we filter the parameters and appropriately give them to the sources they are used in.
To do so I had to initialise the sources with `data = None` a first time, read the defaults and compare the defaults with the parameters given. If the parameters given are in the defaults of one source they are given to a second final initialisation of the source they are used in, this time with the data as well. 

This is probably not the most elegant way to do it, but it works and it makes the initialisation of the likelihood just a bit slower.