### PR TITLE
Issue 53 retrace

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -167,8 +167,6 @@ class LogLikelihood:
             if dname in data:
                 source.set_data(data[dname])
                 # Update batches and padding
-                # TODO changes here should trigger a retrace of ll
-                # how to test this
                 self.n_batches[dname] = source.n_batches
                 self.batch_size[dname] = source.batch_size
                 self.n_padding[dname] = source.n_padding

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -153,9 +153,6 @@ class LogLikelihood:
         # Only trace when we have data
         if trace_ll:
             self.trace_log_likelihood()
-            self.trace_log_likelihood_grad2()
-
-            self.traced_after_set_data = True
 
     def set_data(self,
                  data: ty.Union[pd.DataFrame, ty.Dict[str, pd.DataFrame]],
@@ -188,9 +185,6 @@ class LogLikelihood:
             # When using traced ll, always retrace after setting data since
             # n_events might be different
             self.trace_log_likelihood()
-            self.trace_log_likelihood_grad2()
-
-            self.traced_after_set_data = True
 
     def simulate(self, rate_multipliers=None, fix_truth=None, **params):
         """Simulate events from sources, optionally pass custom
@@ -325,6 +319,8 @@ class LogLikelihood:
 
     def trace_log_likelihood(self):
         self._log_likelihood_tf = tf.function(self._log_likelihood)
+        self._log_likelihood_grad2_tf = tf.function(self._log_likelihood_grad2)
+        self.traced_after_set_data = True
 
     def _log_likelihood_grad2(self, i_batch, dsetname, autograph,
                               omit_grads=tuple(), **params):
@@ -342,9 +338,6 @@ class LogLikelihood:
         hessian = [t2.gradient(grad, grad_par_list) for grad in grads]
         del t2
         return ll, tf.stack(grads), tf.stack(hessian)
-
-    def trace_log_likelihood_grad2(self):
-        self._log_likelihood_grad2_tf = tf.function(self._log_likelihood_grad2)
 
     def _log_likelihood_inner(self, i_batch, params, dsetname, autograph):
         # Does for loop over datasets and sources, not batches

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -55,11 +55,6 @@ class SourceBase:
             # meaning we cannot change the batch_size anymore, check that we
             # are not trying to change it by accident
             assert batch_size is None
-
-            # However, we still have to check if the new data being set is
-            # not less than half the batch size or the padding wont work
-            assert self.n_events * 2 >= self.batch_size, ("batch_size "
-                f"{self.batch_size} is too large for {self.n_events} events")
         else:
             if batch_size is None or batch_size > self.n_events or _skip_tf_init:
                 batch_size = self.n_events

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -143,6 +143,23 @@ def test_set_data_on_no_dset(xes: fd.ERSource):
     ll2 = lf2()
 
 
+def test_retrace_set_data(xes: fd.ERSource):
+    # Test issue #53
+    lf = fd.LogLikelihood(
+        sources=dict(er=fd.ERSource),
+        data=xes.data.copy())
+    ll1 = lf()
+
+    new_data = xes.data.copy()
+    new_data['s2'] *= 2
+    lf.set_data(new_data)
+
+    ll2 = lf()
+
+    # issue 53 would not have retraced ll so lf() would be unchanged
+    assert not ll1 == ll2
+
+
 def test_multi_dset(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=fd.ERSource),


### PR DESCRIPTION
~~_Needs to be merged after #54 , might need a rebase_~~ Done, rebased onto master

This implements retracing of the loglikelihood function (and loglikelihood_grad2) whenever `LogLikelihood.set_data` is called, solving issue #53 

A test has been added to test exactly this issue.

Ideally we would rewrite loglikelihood to accept a `datatensor` and `ptensor` just like the `differential_rate`. Unfortunately we can't write an input signature at the moment since they can't take kwargs.

Edit:
I've added a commit which makes tracing of the likelihood via `set_data` optional (by adding the `autograph` flag to `set_data`). Also when initializing `LogLikelihood` tracing will only be done if data is supplied. This ensures we don't waste time by tracing if we're only calling `log_likelihood` with `autograph=False`.
Since tracing is optional I've added a flag to check whether a retrace has been made after the most recent `set_data` call.
