### PR TITLE
Simulator fix

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -201,9 +201,10 @@ class LogLikelihood:
             else:
                 rm = self._get_rate_mult(sname, params)
 
-            # mean number of events to simulate, rate mult times mu source
-            mu = rm * self.mu_itps[sname](**self._filter_source_kwargs(params,
-                                                                        sname))
+            # mean number of events to simulate, rate mult times mu before
+            # efficiencies, the simulator deals with the efficiencies
+            mu = rm * s.mu_before_efficiencies(
+                **self._filter_source_kwargs(params, sname))
             # Simulate this many events from source
             n_to_sim = np.random.poisson(mu)
             if n_to_sim == 0:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -33,6 +33,12 @@ class SourceBase:
         """
         return dict(), dict(), dict()
 
+    def mu_before_efficiencies(self, **params):
+        """Return mean expected number of events BEFORE efficiencies/response
+        using data for the evaluation of the energy spectra
+        """
+        raise NotImplementedError
+
     def simulate(self, n_events, fix_truth=None, **params):
         """Simulate n events.
 
@@ -133,6 +139,12 @@ class ColumnSource(SourceBase):
         Parameters must be specified as kwarg=(start, stop, n_anchors)
         """
         return lambda **kwargs: cls.mu
+
+    def mu_before_efficiencies(self, **params):
+        """Return the number of expected events without any efficiencies
+        applied.
+        """
+        return self.mu
 
 
 @export
@@ -524,12 +536,6 @@ class Source(SourceBase):
             return mu
 
         return mu_itp
-
-    def mu_before_efficiencies(self, **params):
-        """Return mean expected number of events BEFORE efficiencies/response
-        using data for the evaluation of the energy spectra
-        """
-        raise NotImplementedError
 
     def estimate_mu(self, n_trials=int(1e5), **params):
         """Return estimate of total expected number of events


### PR DESCRIPTION
The `LogLikelihood.simulate` was applying the efficiencies twice (first when determining the mean expected events and then again in `Source.simulate`) leading to underestimated rate multipliers.
Calling `mu_before_efficiencies` in the likelihood and letting `Source.simulate` deal with the efficiencies fixes this.
Calling `mu_before_efficiencies` means all sources must have this method implemented, the abstract method has been moved up to `SourceBase`. `ColumnSource.mu_before_efficiencies` simply returns it's `mu` since it's a fixed rate source. 