### PR TITLE
Simulator checks and timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: xenial
 python:
 - '3.6'
-- '3.7'
+- '3.8'
 install:
 - pip install -r requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: xenial
 python:
 - '3.6'
-- '3.8'
+- '3.7'
 install:
 - pip install -r requirements.txt
 script:

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -208,8 +208,7 @@ class LXeSource(fd.Source):
         super().add_extra_columns(d)
         # Add J2000 timestamps to data for use with wimprates
         if 't' not in d:
-            d['t'] = [wr.j2000(date=t)
-                      for t in pd.to_datetime(d['event_time'])]
+            d['t'] = wr.j2000(d['event_time'])
 
     def validate_fix_truth(self, d):
         """Clean fix_truth, ensure all needed variables are present
@@ -282,8 +281,8 @@ class LXeSource(fd.Source):
 
         # Draw uniform time
         data['event_time'] = np.random.uniform(
-            pd.Timestamp(self.t_start).value,
-            pd.Timestamp(self.t_stop).value,
+            self.t_start.value,
+            self.t_stop.value,
             size=n_events).astype('float32')
         return data
 
@@ -818,8 +817,8 @@ class WIMPSource(NRSource):
         # Times used by wimprates are J2000 timestamps
         assert self.n_in > 1, \
             f"Number of time bin edges needs to be at least 2"
-        times = np.linspace(wr.j2000(date=self.t_start),
-                            wr.j2000(date=self.t_stop), self.n_in)
+        times = np.linspace(wr.j2000(self.t_start.value),
+                            wr.j2000(self.t_stop.value), self.n_in)
         time_centers = self.bin_centers(times)
 
         if wimp_kwargs is None:
@@ -860,12 +859,12 @@ class WIMPSource(NRSource):
         return 0.5 * (x[1:] + x[:-1])
 
     def to_event_time(self, jtimes):
-        j_start = wr.j2000(date=self.t_start)
-        j_stop = wr.j2000(date=self.t_stop)
+        j_start = wr.j2000(self.t_start.value)
+        j_stop = wr.j2000(self.t_stop.value)
         assert j_start < j_stop
 
-        ev_time_start = pd.Timestamp(self.t_start).value
-        ev_time_stop = pd.Timestamp(self.t_stop).value
+        ev_time_start = self.t_start.value
+        ev_time_stop = self.t_stop.value
         assert ev_time_start < ev_time_stop
 
         jfrac = (jtimes - j_start)/(j_stop - j_start)

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -203,11 +203,6 @@ class LXeSource(fd.Source):
         data['energy'] = energies
         return data
 
-    def add_extra_columns(self, d):
-        super().add_extra_columns(d)
-        # Add J2000 timestamps to data for use with wimprates
-        d['t'] = wr.j2000(d['event_time'])
-
     def validate_fix_truth(self, d):
         """Clean fix_truth, ensure all needed variables are present
            Compute derived variables.
@@ -881,12 +876,16 @@ class WIMPSource(NRSource):
         batch = tf.dtypes.cast(i_batch[0], dtype=fd.int_type())
         return self.all_es_centers, self.energy_tensor[batch, :, :]
 
+    def add_extra_columns(self, d):
+        super().add_extra_columns(d)
+        # Add J2000 timestamps to data for use with wimprates
+        d['t'] = wr.j2000(d['event_time'])
+
     def _add_random_energies(self, data, n_events):
         """Draw n_events random energies and times from the energy/
         time spectrum and add them to the data dict.
         """
         events = self.energy_hist.get_random(n_events)
-        data['t'] = j2000_times = events[:, 0]
         data['energy'] = events[:, 1]
-        data['event_time'] = fd.j2000_to_event_time(j2000_times)
+        data['event_time'] = fd.j2000_to_event_time(events[:, 0])
         return data

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -856,18 +856,6 @@ class WIMPSource(NRSource):
     def bin_centers(x):
         return 0.5 * (x[1:] + x[:-1])
 
-    def to_event_time(self, jtimes):
-        j_start = wr.j2000(self.t_start.value)
-        j_stop = wr.j2000(self.t_stop.value)
-        assert j_start < j_stop
-
-        ev_time_start = self.t_start.value
-        ev_time_stop = self.t_stop.value
-        assert ev_time_start < ev_time_stop
-
-        jfrac = (jtimes - j_start)/(j_stop - j_start)
-        return jfrac * (ev_time_stop - ev_time_start) + ev_time_start
-
     def _populate_tensor_cache(self):
         super()._populate_tensor_cache()
         # Get energy bin centers
@@ -900,5 +888,5 @@ class WIMPSource(NRSource):
         events = self.energy_hist.get_random(n_events)
         data['t'] = j2000_times = events[:, 0]
         data['energy'] = events[:, 1]
-        data['event_time'] = self.to_event_time(j2000_times)
+        data['event_time'] = fd.j2000_to_event_time(j2000_times)
         return data

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -53,8 +53,7 @@ class LXeSource(fd.Source):
     # tuple with columns needed from data
     # I guess we don't really need x y z by default, but they are just so nice
     # we should keep them around regardless.
-    extra_needed_columns = tuple(['x', 'y', 'z', 'r',
-                                  'theta', 't', 'event_time'])
+    extra_needed_columns = tuple(['x', 'y', 'z', 'r', 'theta', 'event_time'])
 
     # Whether or not to simulate overdispersion in electron/photon split
     # (e.g. due to non-binomial recombination fluctuation)
@@ -207,8 +206,7 @@ class LXeSource(fd.Source):
     def add_extra_columns(self, d):
         super().add_extra_columns(d)
         # Add J2000 timestamps to data for use with wimprates
-        if 't' not in d:
-            d['t'] = wr.j2000(d['event_time'])
+        d['t'] = wr.j2000(d['event_time'])
 
     def validate_fix_truth(self, d):
         """Clean fix_truth, ensure all needed variables are present

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -50,10 +50,8 @@ class LXeSource(fd.Source):
         'photon_produced',
         'electron_produced')
 
-    # tuple with columns needed from data
-    # I guess we don't really need x y z by default, but they are just so nice
-    # we should keep them around regardless.
-    extra_needed_columns = tuple(['s1', 's2'])
+    def extra_needed_columns(self):
+        return super().extra_needed_columns() + ['s1', 's2']
 
     # Whether or not to simulate overdispersion in electron/photon split
     # (e.g. due to non-binomial recombination fluctuation)
@@ -791,8 +789,8 @@ class WIMPSource(NRSource):
     mw = 1e3  # GeV
     sigma_nucleon = 1e-45  # cm^2
 
-    ignore_columns = tuple(
-        list(NRSource.ignore_columns) + ['wimp_energies'])
+    def ignore_columns(self):
+        return super().ignore_columns() + ['wimp_energies']
 
     # Interpolator settings
     n_in = 10  # Number of time bin edges (wimprates function evaluations + 1)

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -60,11 +60,6 @@ class LogLikelihood:
         :param n_trials:
         :param **common_param_specs:  param_name = (min, max, anchors), ...
         """
-        # Keep track of whether we traced ll after setting data
-        self.traced_after_set_data = False
-        # Only trace when we have data
-        trace_ll = False if data is None else True
-
         param_defaults = dict()
 
         if isinstance(data, pd.DataFrame) or data is None:
@@ -150,20 +145,13 @@ class LogLikelihood:
             log_constraint = lambda **kwargs: 0.
         self.log_constraint = log_constraint
 
-        # Only trace when we have data
-        if trace_ll:
-            self.trace_log_likelihood()
-
     def set_data(self,
-                 data: ty.Union[pd.DataFrame, ty.Dict[str, pd.DataFrame]],
-                 autograph=True):
+                 data: ty.Union[pd.DataFrame, ty.Dict[str, pd.DataFrame]]):
         """set new data for sources in the likelihood.
         Data is passed in the same format as for __init__
         Data can contain any subset of the original data keys to only
         update specific datasets.
         """
-        self.traced_after_set_data = False
-
         if isinstance(data, pd.DataFrame):
             # Only one dataset
             assert len(self.dsetnames) == 1, \
@@ -180,11 +168,6 @@ class LogLikelihood:
                 self.n_padding[dname] = source.n_padding
             elif dname not in self.dsetnames:
                 raise ValueError(f"Dataset name {dname} not known")
-
-        if autograph:
-            # When using traced ll, always retrace after setting data since
-            # n_events might be different
-            self.trace_log_likelihood()
 
     def simulate(self, rate_multipliers=None, fix_truth=None, **params):
         """Simulate events from sources, optionally pass custom
@@ -238,19 +221,12 @@ class LogLikelihood:
 
     def log_likelihood(self, autograph=True, second_order=False,
                        omit_grads=tuple(), **kwargs):
-        if autograph:
-            assert self.traced_after_set_data, \
-                "LL has not been retraced after last setting data"
-
         if second_order:
             # Compute the likelihood, jacobian and hessian
-            # Use only non-tf.function version, in principle works with
-            # but this leads to very long tracing times and we only need
-            # hessian once
             f = self._log_likelihood_grad2
         else:
             # Computes the likelihood and jacobian
-            f = self._log_likelihood_tf if autograph else self._log_likelihood
+            f = self._log_likelihood
 
         params = self.prepare_params(kwargs)
         n_grads = len(self.param_defaults) - len(omit_grads)
@@ -331,11 +307,6 @@ class LogLikelihood:
                 i_batch, params, dsetname, autograph)
         grad = t.gradient(ll, grad_par_list)
         return ll, tf.stack(grad)
-
-    def trace_log_likelihood(self):
-        self._log_likelihood_tf = tf.function(self._log_likelihood)
-        self._log_likelihood_grad2_tf = tf.function(self._log_likelihood_grad2)
-        self.traced_after_set_data = True
 
     def _log_likelihood_grad2(self, i_batch, dsetname, autograph,
                               omit_grads=tuple(), **params):

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -277,10 +277,10 @@ class Source(SourceBase):
             self._calculate_dimsizes()
 
     def _populate_tensor_cache(self):
-        ctc = self.cols_to_cache
 
         # Create one big data tensor (n_batches, events_per_batch, n_cols)
         # TODO: make a list
+        ctc = self.cols_to_cache
         self.data_tensor = tf.constant(self.data[ctc].values,
                                        dtype=fd.float_type())
         self.data_tensor = tf.reshape(self.data_tensor, [self.n_batches,
@@ -406,7 +406,6 @@ class Source(SourceBase):
         return np.concatenate(y)[:self.n_events]
 
     def _batch_data_tensor_shape(self):
-        # return self.data_tensor.shape[1:]
         return [self.batch_size, len(self.name_id)]
 
     def trace_differential_rate(self):

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -104,7 +104,7 @@ class ColumnSource(SourceBase):
         self.data = data
         # No point in batching: computation is trivial
         self.batch_size = len(data) if data is not None else batch_size
-        if data:
+        if data is not None:
             self._init_padding(_skip_tf_init)
             self.data_tensor = fd.np_to_tf(self.data[self.column])
             self.data_tensor = tf.reshape(self.data_tensor,

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -139,12 +139,14 @@ class Source(SourceBase):
     # List all columns that are manually _fetch ed here
     # These will be added to the data_tensor even when the model function
     # inspection will not find them.
-    extra_needed_columns = tuple()
+    def extra_needed_columns(self):
+        return []
 
     # List all columns for which sneaky hacks are used to intercept _fetch here
     # These will not be added to the data tensor even when the model function
     # inspection does find them.
-    ignore_columns = tuple()
+    def ignore_columns(self):
+        return []
 
     data = None
 
@@ -213,9 +215,9 @@ class Source(SourceBase):
 
         # Which columns are needed from data?
         ctc = list(set(sum(self.f_dims.values(), [])))
-        ctc += list(self.extra_needed_columns)
+        ctc += self.extra_needed_columns()
         ctc += [x + '_min' for x in self.inner_dimensions]  # Needed in domain
-        ctc = [x for x in ctc if x not in self.ignore_columns]
+        ctc = [x for x in ctc if x not in self.ignore_columns()]
         self.cols_to_cache = ctc
         self.name_id = fd.index_lookup_dict(ctc)
 
@@ -323,7 +325,7 @@ class Source(SourceBase):
         :param x: column name
         :param data_tensor: Data tensor, columns as in self.name_id
         """
-        if x in self.ignore_columns:
+        if x in self.ignore_columns():
             raise RuntimeError(
                 "Attempt to fetch %s, which is in ignore_columns" % x)
         if data_tensor is None:
@@ -547,9 +549,6 @@ class Source(SourceBase):
 
     def add_extra_columns(self, data):
         """Add additional columns to data
-
-        You must add any columns from data you use here to
-        extra_needed.columns.
 
         :param data: pandas DataFrame
         """

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -103,7 +103,7 @@ class ColumnSource(SourceBase):
         self.defaults = dict()
         self.data = data
         # No point in batching: computation is trivial
-        self.batch_size = len(data) if data else batch_size
+        self.batch_size = len(data) if data is not None else batch_size
         if data:
             self._init_padding(_skip_tf_init)
             self.data_tensor = fd.np_to_tf(self.data[self.column])

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -156,6 +156,7 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
                     res,
                     tf.zeros_like(res, dtype=float_type()))
 
+
 @export
 def is_numpy_number(x):
     try:
@@ -164,11 +165,13 @@ def is_numpy_number(x):
     except (AttributeError, TypeError):
         return False
 
+
 @export
 def symmetrize_matrix(x):
     upper = tf.linalg.band_part(x, 0, -1)
     diag = tf.linalg.band_part(x, 0, 0)
     return (upper - diag) + tf.transpose(upper)
+
 
 @export
 def j2000_to_event_time(dates):
@@ -178,3 +181,11 @@ def j2000_to_event_time(dates):
     zero = pd.to_datetime('2000-01-01T12:00')
     nanoseconds_per_day = 1e9 * 3600 * 24
     return nanoseconds_per_day * dates + zero.value
+
+
+@export
+def index_lookup_dict(names):
+    return dict(zip(
+        names,
+        [tf.constant(i, dtype=INT_TYPE)
+         for i in range(len(names))]))

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import tensorflow as tf
 import tensorflow_probability as tfp
 # Remove once tf.repeat is available in the tf api
@@ -168,3 +169,12 @@ def symmetrize_matrix(x):
     upper = tf.linalg.band_part(x, 0, -1)
     diag = tf.linalg.band_part(x, 0, 0)
     return (upper - diag) + tf.transpose(upper)
+
+@export
+def j2000_to_event_time(dates):
+    """Convert a numpy array of j2000 timestamps to event_times
+    which are ns unix timestamps. This is the reverse of wimprates.j2000
+    """
+    zero = pd.to_datetime('2000-01-01T12:00')
+    nanoseconds_per_day = 1e9 * 3600 * 24
+    return nanoseconds_per_day * dates + zero.value

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -187,5 +187,5 @@ def j2000_to_event_time(dates):
 def index_lookup_dict(names):
     return dict(zip(
         names,
-        [tf.constant(i, dtype=INT_TYPE)
+        [tf.constant(i, dtype=int_type())
          for i in range(len(names))]))

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -70,10 +70,6 @@ s1_map, s2_map = [
 class SR0Source:
     # TODO: add p_el_sr0
 
-    extra_needed_columns = tuple(
-        list(fd.ERSource.extra_needed_columns)
-        + ['x_observed', 'y_observed'])
-
     def random_truth(self, energies, fix_truth=None, **params):
         d = super().random_truth(energies, fix_truth=fix_truth, **params)
         # TODO: Add field distortion maps
@@ -106,16 +102,12 @@ class SR0Source:
 
 @export
 class SR0ERSource(SR0Source, fd.ERSource):
-    extra_needed_columns = tuple(set(
-        list(SR0Source.extra_needed_columns) +
-        list(fd.ERSource.extra_needed_columns)))
+    pass
 
 
 @export
 class SR0NRSource(SR0Source, fd.NRSource):
-    extra_needed_columns = tuple(set(
-        list(SR0Source.extra_needed_columns) +
-        list(fd.NRSource.extra_needed_columns)))
+    pass
 
 
 @export
@@ -124,9 +116,6 @@ class SR0WIMPSource(SR0Source, fd.WIMPSource):
     This describes an SR0-like WIMP source, not THE
     SR0 source. The time range is not changed from the default.
     """
-    extra_needed_columns = tuple(set(
-        list(SR0Source.extra_needed_columns) +
-        list(fd.WIMPSource.extra_needed_columns)))
     # WIMP settings
     es = np.geomspace(0.7, 50, 100)  # [keV]
     mw = 1e3  # GeV

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -30,9 +30,6 @@ s1_map, s2_map = [
 
 class SR1Source:
     drift_velocity = 1.335 * 1e-4   # cm/ns
-    extra_needed_columns = tuple(
-        list(fd.ERSource.extra_needed_columns)
-        + ['x_observed', 'y_observed'])
 
     def random_truth(self, n_events, fix_truth=None, **params):
         d = super().random_truth(n_events, fix_truth=fix_truth, **params)
@@ -116,11 +113,6 @@ class SR1ERSource(SR1Source,fd.ERSource):
 
 @export
 class SR1NRSource(SR1Source, fd.NRSource):
-    extra_needed_columns = tuple(set(
-        list(SR1Source.extra_needed_columns) +
-        list(fd.NRSource.extra_needed_columns)+
-        ['x_observed', 'y_observed']))
-
     # TODO: Define the proper nr spectrum
     # TODO: Modify the SR1NRSource to fit AmBe data better
 

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -45,8 +45,8 @@ class SR1Source:
                                            scale=2)  # 2cm resolution)
         return d
 
-    @staticmethod
-    def add_extra_columns(d):
+    def add_extra_columns(self, d):
+        super().add_extra_columns(d)
         d['s2_relative_ly'] = s2_map(
              np.transpose([d['x_observed'].values,
                           d['y_observed'].values]))
@@ -154,6 +154,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
 
         return fd.safe_p(n_el / nq)
 
+@export
 class SR1WIMPSource(SR1NRSource, fd.WIMPSource):
     extra_needed_columns = tuple(set(
         list(SR1NRSource.extra_needed_columns) +

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -28,7 +28,6 @@ s1_map, s2_map = [
 ##
 
 
-@export
 class SR1Source:
     drift_velocity = 1.335 * 1e-4   # cm/ns
     extra_needed_columns = tuple(
@@ -67,15 +66,15 @@ class SR1Source:
 
     @staticmethod
     def electron_gain_std(s2_relative_ly, *, g2=11.4/(1.-0.63)/0.96):
-        return g2*0.96*0.25+0.*s2_relative_ly    
+        return g2*0.96*0.25+0.*s2_relative_ly
 
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
-    def photon_detection_eff(s1_relative_ly, g1 =0.142): 
+    def photon_detection_eff(s1_relative_ly, g1 =0.142):
         #g1 = 0.142 from paper
         mean_eff= g1 / (1. + 0.219)
         return mean_eff * s1_relative_ly
-    
+
 
 
 # ER Source for SR1
@@ -83,22 +82,22 @@ class SR1Source:
 class SR1ERSource(SR1Source,fd.ERSource):
 
     @staticmethod
-    def p_electron(nq, W=13.8e-3, mean_nexni=0.135,  q0=1.13, q1=0.47, 
-                   gamma_er=0.031 , omega_er=31.): 
+    def p_electron(nq, W=13.8e-3, mean_nexni=0.135,  q0=1.13, q1=0.47,
+                   gamma_er=0.031 , omega_er=31.):
         # gamma_er from paper 0.124/4
 
         F = tf.constant(81.,dtype=fd.float_type())
-        
+
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-0.24) 
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-0.24)
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant
         r_er = 1. - tf.math.log(1. + ni * wiggle_er) / (ni * wiggle_er)
         r_er /= (1. + tf.exp(-(e_kev - q0) / q1))
         p_el = ni * (1. - r_er) / nq
-        
+
         return fd.safe_p(p_el)
 
     @staticmethod
@@ -115,14 +114,18 @@ class SR1ERSource(SR1Source,fd.ERSource):
                         tf.zeros_like(s2, dtype=fd.float_type()),
                         tf.ones_like(s2, dtype=fd.float_type()))
 
+@export
 class SR1NRSource(SR1Source, fd.NRSource):
     extra_needed_columns = tuple(set(
-        list(SR1Source.extra_needed_columns) + 
+        list(SR1Source.extra_needed_columns) +
         list(fd.NRSource.extra_needed_columns)+
         ['x_observed', 'y_observed']))
 
+    # TODO: Define the proper nr spectrum
+    # TODO: Modify the SR1NRSource to fit AmBe data better
+
     def p_electron(self, nq, *,
-            alpha=1.280, zeta=0.045, beta=273 * .9e-4, 
+            alpha=1.280, zeta=0.045, beta=273 * .9e-4,
             gamma=0.0141, delta=0.062,
             drift_field=81):
         """Fraction of detectable NR quanta that become electrons,
@@ -150,7 +153,8 @@ class SR1NRSource(SR1Source, fd.NRSource):
         n_el = ni * fnotr
 
         return fd.safe_p(n_el / nq)
-    
-    #TODO: Define the proper nr spectrum
 
-# TODO: Modify the SR1NRSource to fit AmBe data better and add WIMPSource
+class SR1WIMPSource(SR1NRSource, fd.WIMPSource):
+    extra_needed_columns = tuple(set(
+        list(SR1NRSource.extra_needed_columns) +
+        list(fd.WIMPSource.extra_needed_columns)))

--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -146,8 +146,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
 
         return fd.safe_p(n_el / nq)
 
+
 @export
 class SR1WIMPSource(SR1NRSource, fd.WIMPSource):
-    extra_needed_columns = tuple(set(
-        list(SR1NRSource.extra_needed_columns) +
-        list(fd.WIMPSource.extra_needed_columns)))
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 pandas
 multihist
-wimprates
+wimprates>=0.3.1
 tqdm
 tensorflow>=2.0.0
 tensorflow_probability>=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pandas
 multihist
 wimprates
 tqdm
-tensorflow==2.0.0
-tensorflow_probability==0.8.0
+tensorflow>=2.0.0
+tensorflow_probability>=0.8.0
 iminuit

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 import setuptools
 
-# Get requirements from requirements.txt, stripping the version tags
+# Get requirements from requirements.txt
 with open('requirements.txt') as f:
-    requires = [x.strip().split('=')[0]
-                for x in f.readlines()]
+    requires = [x.strip() for x in f.readlines()]
 
 with open('README.md') as file:
     readme = file.read()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -15,9 +15,11 @@ n_events = 2
 def xes(request):
     # warnings.filterwarnings("error")
     data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
-                              x=2., y=0.4, z=-20, r=2.1, theta=0.1),
+                              x=2., y=0.4, z=-20, r=2.1, theta=0.1,
+                              event_time=15e17),
                          dict(s1=23, s2=1080., drift_time=445622.,
-                              x=1.12, y=0.35, z=-59., r=1., theta=0.3)])
+                              x=1.12, y=0.35, z=-59., r=1., theta=0.3,
+                              event_time=15e17)])
     if request.param == 'ER':
         x = fd.ERSource(data.copy(), batch_size=2, max_sigma=8)
     else:

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -25,6 +25,17 @@ def xes(request):
     return x
 
 
+def test_wimp_SR1_source(xes):
+    # test KeyError 't' issue, because of add_extra_columns bug
+    lf = fd.LogLikelihood(sources=dict(er=fd.SR1ERSource,
+                                       wimp=fd.SR1WIMPSource),
+                          free_rates=('er', 'wimp'))
+
+    d = lf.simulate(er_rate_multiplier=1.0,
+                    wimp_rate_multiplier=0.)
+    lf.set_data(d)
+
+
 def test_inference(xes: fd.ERSource):
     lf = fd.LogLikelihood(
         sources=dict(er=xes.__class__),

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -14,7 +14,7 @@ def xes(request):
     # warnings.filterwarnings("error")
     data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
                               x=2., y=0.4, z=-20, r=2.1, theta=0.1,
-                              event_time=15e17)
+                              event_time=15e17),
                          dict(s1=23, s2=1080., drift_time=445622.,
                               x=1.12, y=0.35, z=-59., r=1., theta=0.3,
                               event_time=15e17)])

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -13,9 +13,11 @@ n_events = 2
 def xes(request):
     # warnings.filterwarnings("error")
     data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
-                              x=2., y=0.4, z=-20, r=2.1, theta=0.1),
+                              x=2., y=0.4, z=-20, r=2.1, theta=0.1,
+                              event_time=15e17)
                          dict(s1=23, s2=1080., drift_time=445622.,
-                              x=1.12, y=0.35, z=-59., r=1., theta=0.3)])
+                              x=1.12, y=0.35, z=-59., r=1., theta=0.3,
+                              event_time=15e17)])
     if request.param == 'ER':
         x = fd.ERSource(data.copy(), batch_size=2, max_sigma=8)
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import wimprates as wr
+import flamedisx as fd
+
+def test_j2000_conversion():
+    j2000_times = pd.np.linspace(0., 10000., 100)
+
+    # convert j2000 -> event_time -> j2000
+    test_times = wr.j2000(fd.j2000_to_event_time(j2000_times))
+
+    pd.np.testing.assert_array_almost_equal(j2000_times,
+                                            test_times,
+                                            decimal=6)


### PR DESCRIPTION
Larger changes and improvements:

 - Ensure that `Source.differential_rate` only needs to be traced once during the lifetime of a Source object.
   - Tracing is now defined in the source initialization since the input signature is known.
   - We use `tf.function` to graph the diff rate function and supply an input signature for it. This means that if only the values (and not the shape and dtype) of `data_tensor` and `ptensor` change we don't need to retrace. However we were actually retracing on every `set_data` call which is now fixed. This means that we also had to merge `energy_tensor` and `spatial_rate_tensor` into `data_tensor` so that all is passed through `_differential_rate`.
- Remove all tracing in `log_likelihood`
  - Most of the performance gain from using `tf.function` is due to `differential_rate`, also tracing `log_likelihood` doesn't add more speed but instead introduces overhead from tracing. `log_likelihood` also needs to be traced every `set_data` (which also retraces diff rate unnecessarily). Removing all tracing in `LogLikelihood` speeds up toyMCs from about 24 s per toy (including simulation, bestfit and interval estimation) to about 18 s.
 - Reduced memory usage for toyMCs
   - Repeatedly tracing functions using `tf.function` takes up a lot of RAM. Before we could not run more than 400 toysMCs in one runtime. Tracing only once (on diff rate) fixes this.

Smaller changes and improvements:

- Added SR1WIMPSource class to `x1t_sr1.py`, exporting `SR1NRSource` and `SR1WIMPSource` but not `SR1Source` to be consistent with `x1t_sr0.py`
- Made `LogLikelihood.simulate` more robust:
  - Added a check that checks if all sources that were simulated returned DataFrames with the same columns, this is important since columns not in all sources will be filled with NaN values that might lead to problems later on.
  - Skip sources that return 0 events (either because no events are left due to efficiencies or because they don't have simulate implemented).
  - Ensure that pd.concat doesn't crash if all sources returned 0 events (which is possible with small rate_multipliers) by adding an empty DataFrame to the list.
- ~~One case where different sources returned dataframes with different columns was when combining ERSource with WIMPSource. The ERSource does not have the J2000 't' times and as a result after `LogLikelihood.simulate` these would be NaN. This behaviour is now caught by the above check. Additionally generating the J2000 times is moved up to `LXeSource` such that we now can combine all Sources derived from `LXeSource`.~~
  - It turns out `add_extra_columns` in `SR1Source` didn't call its super() so was overwriting the method from `LXeSource`. This is why data was not annotated with the J2000 timestamps for WIMP sources and I fixed it by computing J2000 timestamps for all sources.
Now that `add_extra_columns` works correctly I've restored the original implementation.
- Relaxed the requirements on `tensorflow` and `tensorflow_probability` in requirements, adjusted `setup.py` accordingly.
- I've also cleaned up the conversion of J2000 timestamps back to event times (since we now know it's simply scaling unix time).
- pinned required wimprates version to >= 0.3.1 since the j2000 api has changed
- added j2000_to_event_time conversion in utils (and added test for it)
- Tried Py3.8 build but TF2 not yet supported, so keep at Py3.7 for now
