### PR TITLE
Tilt to objective, inference refactor

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -82,7 +82,10 @@ class Objective:
         self.return_errors = return_errors
         self.optimizer_kwargs = optimizer_kwargs
 
-        self.arg_names = [k for k in self.lf.param_names if k not in self.fix]
+        # The if is only here to support MockInference with static arg_names
+        if self.arg_names is None:
+            self.arg_names = [
+                k for k in self.lf.param_names if k not in self.fix]
         self._cache = dict()
         if self.return_history:
             self._history = []

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -313,6 +313,7 @@ class IntervalObjective(Objective):
                  bestfit,
                  direction: int,
                  critical_quantile,
+                 tilt_multiplier=1.,
                  sigma_guess=None,
                  t_ppf=None,
                  t_ppf_grad=None,
@@ -323,6 +324,7 @@ class IntervalObjective(Objective):
         self.bestfit = bestfit
         self.direction = direction
         self.critical_quantile = critical_quantile
+        self.tilt_multiplier = tilt_multiplier
 
         if sigma_guess is None:
             # Estimate one sigma interval using parabolic approx.
@@ -338,7 +340,7 @@ class IntervalObjective(Objective):
 
         # TODO: add reference to computation for this
         # TODO: let user specify multiplier for this
-        self.tilt = self.sigma_guess * \
+        self.tilt = self.sigma_guess * self.tilt_multiplier * \
             (8 * self.llr_tolerance * self.critical_quantile)**0.5
 
         # Store bestfit target, maximum likelihood and slope

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -9,8 +9,8 @@ from iminuit import Minuit
 
 export, __all__ = fd.exporter()
 __all__ += ['LOWER_RATE_MULTIPLIER_BOUND',
-            'BESTFIT_OBJECTIVES',
-            'INTERVAL_OBJECTIVES']
+            'SUPPORTED_OPTIMIZERS',
+            'SUPPORTED_INTERVAL_OPTIMIZERS']
 
 # Setting this to 0 does work, but makes the inference rather slow
 # (at least for scipy); probably there is a relative xtol computation,
@@ -272,9 +272,9 @@ class MinuitObjective(Objective):
         return fit.fitarg
 
 
-BESTFIT_OBJECTIVES = dict(tfp=TensorFlowObjective,
-                          minuit=MinuitObjective,
-                          scipy=ScipyObjective)
+SUPPORTED_OPTIMIZERS = dict(tfp=TensorFlowObjective,
+                            minuit=MinuitObjective,
+                            scipy=ScipyObjective)
 
 
 ##
@@ -412,6 +412,6 @@ class ScipyIntervalObjective(IntervalObjective, ScipyObjective):
     """IntervalObjective using Scipy optimizer"""
 
 
-INTERVAL_OBJECTIVES = dict(tfp=TensorFlowIntervalObjective,
-                           minuit=MinuitIntervalObjective,
-                           scipy=ScipyIntervalObjective)
+SUPPORTED_INTERVAL_OPTIMIZERS = dict(tfp=TensorFlowIntervalObjective,
+                                     minuit=MinuitIntervalObjective,
+                                     scipy=ScipyIntervalObjective)

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -378,6 +378,9 @@ class IntervalObjective(Objective):
                       **{self.target_parameter: tp_guess},
                       **self.guess}
 
+        # Objective is squared, so square the tolerance:
+        self.llr_tolerance = self.llr_tolerance ** 2
+
     def t_ppf(self, target_param_value):
         """Return critical value given parameter value and critical
         quantile.

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -377,7 +377,8 @@ class LogLikelihood:
         if not isinstance(guess, dict):
             raise ValueError("Must specify bestfit guess as a dictionary")
 
-        res = fd.BESTFIT_OBJECTIVES[optimizer](
+        opt = fd.SUPPORTED_OPTIMIZERS[optimizer]
+        res = opt(
             lf=self,
             guess={**self.guess(), **guess},
             fix=fix,
@@ -404,7 +405,13 @@ class LogLikelihood:
 
         return result
 
-    def one_parameter_interval(
+    def interval(self, parameter, **kwargs):
+        """Return central confidence interval on parameter.
+        Options are the same as for limit."""
+        kwargs.setdefault('kind', 'central')
+        return self.limit(parameter, **kwargs)
+
+    def limit(
             self,
             parameter,
             bestfit=None,
@@ -419,7 +426,7 @@ class LogLikelihood:
             optimizer='scipy',
             llr_tolerance=0.05,
             optimizer_kwargs=None,):
-        """Return frequentist confidence interval or limit
+        """Return frequentist limit or confidence interval
 
         :param parameter: string, the parameter to set the interval on
         :param bestfit: {parameter: value} dictionary, global best-fit.
@@ -429,7 +436,7 @@ class LogLikelihood:
         If omitted, guess for target parameters will be based on asymptotic
         parabolic computation.
         :param fix: {param: value} to fix during interval computation.
-        Intervals are only valid if same parameters were fixed for bestfit.
+        Result is only valid if same parameters were fixed for bestfit.
         :param confidence_level: Requried confidence level of the interval
         :param kind: Type of interval, 'upper', 'lower' or 'central'
         :param sigma_guess: Guess for one sigma uncertainty on the target
@@ -491,7 +498,8 @@ class LogLikelihood:
                 # The objective is squared:
                 llr_tolerance = llr_tolerance ** 2
 
-            res = fd.INTERVAL_OBJECTIVES[optimizer](
+            opt = fd.SUPPORTED_INTERVAL_OPTIMIZERS[optimizer]
+            res = opt(
                 # To generic objective
                 lf=self,
                 guess=req['guess'],

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -6,7 +6,6 @@ import typing as ty
 
 
 export, __all__ = fd.exporter()
-__all__ += ['DEFAULT_DSETNAME']
 
 o = tf.newaxis
 DEFAULT_DSETNAME = 'the_dataset'
@@ -504,6 +503,7 @@ class LogLikelihood:
         result = []
         for req in requested_limits:
             opt = fd.SUPPORTED_INTERVAL_OPTIMIZERS[optimizer]
+
             res = opt(
                 # To generic objective
                 lf=self,

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -429,9 +429,12 @@ class LogLikelihood:
             optimizer='scipy',
             get_history=False,
             get_lowlevel_result=False,
-            # Broader tolerance than for bestfit, llr is steep at limit
-            llr_tolerance=0.05,
-            tilt_multiplier=1.,
+            # Broader tolerance than for bestfit, llr is steep at limit.
+            # Set so 90% CL intervals actually report ~90.25% intervals
+            # asymptotically due to the tilt.
+            llr_tolerance=0.037,
+            # Multiplier for optimizer tolerance.
+            tol_multiplier=3e-3,
             optimizer_kwargs=None,):
         """Return frequentist limit or confidence interval
 
@@ -519,7 +522,7 @@ class LogLikelihood:
                 bestfit=bestfit,
                 direction=req['direction'],
                 critical_quantile=req['crit'],
-                tilt_multiplier=tilt_multiplier,
+                tol_multiplier=tol_multiplier,
                 sigma_guess=sigma_guess,
                 t_ppf=t_ppf,
                 t_ppf_grad=t_ppf_grad,

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -347,6 +347,7 @@ class LogLikelihood:
                 optimizer='scipy',
                 llr_tolerance=0.01,
                 get_lowlevel_result=False,
+                get_history=False,
                 use_hessian=True,
                 return_errors=False,
                 nan_val=float('inf'),
@@ -363,7 +364,9 @@ class LogLikelihood:
         less than this.
         becomes less than this.
         :param get_lowlevel_result: Returns the full optimizer result instead
-        of only the best fit parameters. Bool.
+        of the best fit parameters. Bool.
+        :param get_history: Returns the history of optimizer calls instead
+        of the best fit parameters. Bool.
         :param use_hessian: Passes the hessian estimated at the guess to the
         optimizer. Bool.
         :param return_errors: If using the minuit minimizer, instead return
@@ -386,11 +389,12 @@ class LogLikelihood:
             llr_tolerance=llr_tolerance,
             nan_val=nan_val,
             get_lowlevel_result=get_lowlevel_result,
+            get_history=get_history,
             use_hessian=use_hessian,
             return_errors=return_errors,
             optimizer_kwargs=optimizer_kwargs
         ).minimize()
-        if get_lowlevel_result:
+        if get_lowlevel_result or get_history:
             return res
 
         # TODO: This is to deal with a minuit-specific convention,
@@ -424,6 +428,8 @@ class LogLikelihood:
             t_ppf_grad=None,
             # Broader tolerance than for bestfit, llr is steep at limit
             optimizer='scipy',
+            get_history=False,
+            get_lowlevel_result=False,
             llr_tolerance=0.05,
             optimizer_kwargs=None,):
         """Return frequentist limit or confidence interval
@@ -507,7 +513,8 @@ class LogLikelihood:
                 bounds={parameter: req['bound']},
                 llr_tolerance=llr_tolerance,
                 # TODO: nan_val
-                get_lowlevel_result=False,
+                get_lowlevel_result=get_lowlevel_result,
+                get_history=get_history,
                 use_hessian=False,
                 optimizer_kwargs=optimizer_kwargs,
 
@@ -520,8 +527,10 @@ class LogLikelihood:
                 t_ppf=t_ppf,
                 t_ppf_grad=t_ppf_grad,
             ).minimize()
-
-            result.append(res[parameter])
+            if get_lowlevel_result or get_history:
+                result.append(res)
+            else:
+                result.append(res[parameter])
 
         if len(result) == 1:
             return result[0]

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -426,11 +426,12 @@ class LogLikelihood:
             sigma_guess=None,
             t_ppf=None,
             t_ppf_grad=None,
-            # Broader tolerance than for bestfit, llr is steep at limit
             optimizer='scipy',
             get_history=False,
             get_lowlevel_result=False,
+            # Broader tolerance than for bestfit, llr is steep at limit
             llr_tolerance=0.05,
+            tilt_multiplier=1.,
             optimizer_kwargs=None,):
         """Return frequentist limit or confidence interval
 
@@ -523,6 +524,7 @@ class LogLikelihood:
                 bestfit=bestfit,
                 direction=req['direction'],
                 critical_quantile=req['crit'],
+                tilt_multiplier=tilt_multiplier,
                 sigma_guess=sigma_guess,
                 t_ppf=t_ppf,
                 t_ppf_grad=t_ppf_grad,

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -500,11 +500,6 @@ class LogLikelihood:
 
         result = []
         for req in requested_limits:
-
-            if llr_tolerance is not None:
-                # The objective is squared:
-                llr_tolerance = llr_tolerance ** 2
-
             opt = fd.SUPPORTED_INTERVAL_OPTIMIZERS[optimizer]
             res = opt(
                 # To generic objective

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -203,14 +203,14 @@ class Source:
         if data is None:
             self.set_defaults(**kwargs)
         else:
-            old_data = self.data
+            old_data = self.data[:self.n_events]  # Remove padding
             self.set_data(data, **kwargs, _skip_tf_init=True)
         try:
             yield
         finally:
             self.defaults = old_defaults
             if data is not None:
-                self.data = old_data
+                self.set_data(old_data, _skip_tf_init=True)
 
     def annotate_data(self, data, _skip_bounds_computation=False, **params):
         """Add columns to data with inference information"""

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -197,19 +197,24 @@ class Source:
             self.dimsizes[var] = int(tf.reduce_max(ma - mi + 1).numpy())
 
     @contextmanager
-    def _set_temporarily(self, data=None, **kwargs):
+    def _set_temporarily(self, data, **kwargs):
         """Set data and/or defaults temporarily"""
+        if data is None:
+            raise ValueError("No point in setting data = None temporarily")
         old_defaults = self.defaults
         if data is None:
             self.set_defaults(**kwargs)
         else:
-            old_data = self.data[:self.n_events]  # Remove padding
+            if self.data is None:
+                old_data = None
+            else:
+                old_data = self.data[:self.n_events]  # Remove padding
             self.set_data(data, **kwargs, _skip_tf_init=True)
         try:
             yield
         finally:
             self.defaults = old_defaults
-            if data is not None:
+            if old_data is not None:
                 self.set_data(old_data, _skip_tf_init=True)
 
     def annotate_data(self, data, _skip_bounds_computation=False, **params):

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from scipy import stats
 import tensorflow as tf
 import tensorflow_probability as tfp
 # Remove once tf.repeat is available in the tf api
@@ -196,3 +197,9 @@ def values_to_constants(kwargs):
         if isinstance(v, (float, int)) or is_numpy_number(v):
             kwargs[k] = tf.constant(v, dtype=float_type())
     return kwargs
+
+
+@export
+def wilks_crit(confidence_level):
+    """Return critical value from Wilks' theorem for upper limits"""
+    return stats.norm.ppf(confidence_level) ** 2

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -48,10 +48,6 @@ def test_one_parameter_interval(xes):
     ul = lf.limit('er_rate_multiplier', bestfit, fix=fix,
                   confidence_level=0.9, kind='upper')
 
-    ul = lf.limit('er_rate_multiplier', bestfit, fix=fix,
-                  optimizer='magic',
-                  confidence_level=0.9, kind='upper')
-
 
 def test_bestfit_tf(xes):
     # Test bestfit (including hessian)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -29,24 +29,28 @@ def test_one_parameter_interval(xes):
     # First find global best so we can check intervals
     bestfit = lf.bestfit(guess, optimizer='scipy')
 
-    ul = lf.one_parameter_interval('er_rate_multiplier', bestfit,
-                                   confidence_level=0.9, kind='upper')
+    ul = lf.limit('er_rate_multiplier', bestfit,
+                  confidence_level=0.9, kind='upper')
     assert ul >= bestfit['er_rate_multiplier']
 
-    ll = lf.one_parameter_interval('er_rate_multiplier', bestfit,
-                                   confidence_level=0.9, kind='lower')
+    ll = lf.limit('er_rate_multiplier', bestfit,
+                  confidence_level=0.9, kind='lower')
     assert ll <= bestfit['er_rate_multiplier']
 
-    ll, ul = lf.one_parameter_interval('er_rate_multiplier', bestfit,
-                                       confidence_level=0.9, kind='central')
+    ll, ul = lf.limit('er_rate_multiplier', bestfit,
+                      confidence_level=0.9, kind='central')
     assert (ll <= bestfit['er_rate_multiplier']
             and ul >= bestfit['er_rate_multiplier'])
 
     # Test fixed parameter
     fix = dict(elife=bestfit['elife'])
 
-    ul = lf.one_parameter_interval('er_rate_multiplier', bestfit, fix=fix,
-                                   confidence_level=0.9, kind='upper')
+    ul = lf.limit('er_rate_multiplier', bestfit, fix=fix,
+                  confidence_level=0.9, kind='upper')
+
+    ul = lf.limit('er_rate_multiplier', bestfit, fix=fix,
+                  optimizer='magic',
+                  confidence_level=0.9, kind='upper')
 
 
 def test_bestfit_tf(xes):
@@ -93,7 +97,7 @@ def test_bestfit_minuit(xes):
 
     bestfit = lf.bestfit(guess, optimizer='minuit',
                          return_errors=True,
-                         error=(0.0001, 1000))
+                         optimizer_kwargs=dict(error=(0.0001, 1000)))
     assert isinstance(bestfit[0], dict)
     assert len(bestfit[0]) == 2
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,30 +1,10 @@
 import numpy as np
-import pandas as pd
-import pytest
-import tensorflow as tf
-import tensorflow_probability as tfp
-from iminuit import Minuit
 
 import flamedisx as fd
-from flamedisx.likelihood import DEFAULT_DSETNAME
+from test_source import xes   # Yes, it is used through pytest magic
 
 
 n_events = 2
-
-@pytest.fixture(params=["ER", "NR"])
-def xes(request):
-    # warnings.filterwarnings("error")
-    data = pd.DataFrame([dict(s1=56., s2=2905., drift_time=143465.,
-                              x=2., y=0.4, z=-20, r=2.1, theta=0.1,
-                              event_time=15e17),
-                         dict(s1=23, s2=1080., drift_time=445622.,
-                              x=1.12, y=0.35, z=-59., r=1., theta=0.3,
-                              event_time=15e17)])
-    if request.param == 'ER':
-        x = fd.ERSource(data.copy(), batch_size=2, max_sigma=8)
-    else:
-        x = fd.NRSource(data.copy(), batch_size=2, max_sigma=8)
-    return x
 
 
 def test_one_parameter_interval(xes):

--- a/tests/test_mock_inference.py
+++ b/tests/test_mock_inference.py
@@ -10,7 +10,7 @@ arg_names = ['er_rate_multplier', 'elife']
 truth_test = np.array([2., 3.])
 
 
-@pytest.fixture(params=fd.BESTFIT_OBJECTIVES.values())
+@pytest.fixture(params=fd.SUPPORTED_OPTIMIZERS.values())
 def mock_objective(request):
 
     class MockObjective(request.param):

--- a/tests/test_mock_inference.py
+++ b/tests/test_mock_inference.py
@@ -1,128 +1,70 @@
 import numpy as np
-import pandas as pd
 import pytest
 import tensorflow as tf
-import tensorflow_probability as tfp
-from iminuit import Minuit
 
 import flamedisx as fd
-from flamedisx.likelihood import DEFAULT_DSETNAME
-from flamedisx.inference import (ScipyObjective,
-                                 TensorFlowObjective,
-                                 MinuitObjective)
-
 
 n_events = 2
 
-class MockObjective:
-    def _inner_fun_and_grad(self, params):
-        # Return -2lnL and -2lnL gradient
-        # Use simple parabola with NaN bounds for rate multipliers
-        # Set true parameters in self.truths[param_name] before
-        ll = 0
-        grads_to_return = [p for p in params if p not in self.fix.keys()]
-        n_grads = len(grads_to_return)
-        ll_grad_dict = {k: 0 for k in grads_to_return}
-
-        for k, v in params.items():
-            v = v.numpy()
-            if k.endswith('_rate_multiplier') and v <= 0.:
-                ll = float('nan')
-                ll_grad = [float('nan')] * n_grads
-                break
-            # Add parabola
-            ll += (v - self.truths[k]) ** 2
-            ll_grad_dict[k] += 2 * (v - self.truths[k])
-        return (tf.constant(ll, dtype=fd.float_type()),
-                tf.constant(list(ll_grad_dict.values()), dtype=fd.float_type()))
+arg_names = ['er_rate_multplier', 'elife']
+truth_test = np.array([2., 3.])
 
 
-class MockScipyObjective(MockObjective, ScipyObjective):
-    pass
+@pytest.fixture(params=fd.BESTFIT_OBJECTIVES.values())
+def mock_objective(request):
+
+    class MockObjective(request.param):
+        def __init__(self, *, truths, **kwargs):
+            self.arg_names = list(truths.keys())
+            self.truths = truths
+            super().__init__(**kwargs)
+
+        def _inner_fun_and_grad(self, params):
+            # Return -2lnL and -2lnL gradient
+            # Use simple parabola with NaN bounds for rate multipliers
+            # Set true parameters in self.truths[param_name] before
+            ll = 0
+            grads_to_return = [p for p in params if p not in self.fix.keys()]
+            n_grads = len(grads_to_return)
+            ll_grad_dict = {k: 0 for k in grads_to_return}
+
+            for k, v in params.items():
+                # TODO: investigate and remove hack
+                try:
+                    v = v.numpy()
+                except AttributeError:
+                    pass
+
+                if k.endswith('_rate_multiplier') and v <= 0.:
+                    ll = float('nan')
+                    ll_grad = [float('nan')] * n_grads
+                    break
+                # Add parabola
+                ll += (v - self.truths[k]) ** 2
+                ll_grad_dict[k] += 2 * (v - self.truths[k])
+            return (tf.constant(ll, dtype=fd.float_type()),
+                    tf.constant(list(ll_grad_dict.values()), dtype=fd.float_type()))
+
+    truths = {k: truth_test[i] for i, k in enumerate(arg_names)}
+    guess = {k: 1. for k in arg_names}
+
+    return MockObjective(
+        lf=None,
+        truths=truths,
+        guess=guess,
+        fix=dict(),
+        llr_tolerance=0.001,
+        nan_val=float('nan'),
+        get_lowlevel_result=False,
+        # We haven't defined a mock grad2
+        use_hessian=False)
 
 
-class MockTensorFlowObjective(MockObjective, TensorFlowObjective):
-    pass
-
-
-class MockMinuitObjective(MockObjective, MinuitObjective):
-    pass
-
-
-def test_mock_bestfit_tf():
+def test_mock_bestfit_tf(mock_objective):
     # Test bestfit (including hessian)
-    arg_names = ['er_rate_multiplier', 'elife']
-    mock_opt = MockTensorFlowObjective(lf=None,
-                                       arg_names=arg_names,
-                                       fix=dict(),
-                                       autograph=True,
-                                       nan_val=float('nan'))
-
-    truths = dict(er_rate_multiplier=2.,
-                  elife=2.)
-    truth_test = np.array([truths[k] for k in arg_names])
-    mock_opt.truths = truths
-    x_guess = np.array([1., 1.])  # optmizer start
-
-    res = mock_opt.minimize(x_guess,
-                            get_lowlevel_result=False,
-                            # We haven't defined a mock grad2
-                            use_hessian=False,
-                            llr_tolerance=0.1)
-
-    res_test = np.array([res[k] for k in arg_names])
-
-    np.testing.assert_array_almost_equal(truth_test,
-                                         res_test, decimal=3)
-
-
-def test_mock_bestfit_minuit():
-    # Test bestfit (including hessian)
-    arg_names = ['er_rate_multiplier', 'elife']
-    mock_opt = MockMinuitObjective(lf=None,
-                                   arg_names=arg_names,
-                                   fix=dict(),
-                                   autograph=True,
-                                   nan_val=float('nan'))
-
-    truths = dict(er_rate_multiplier=2.,
-                  elife=2.)
-    truth_test = np.array([truths[k] for k in arg_names])
-    mock_opt.truths = truths
-    x_guess = np.array([1., 1.])
-
-    res = mock_opt.minimize(x_guess,
-                            get_lowlevel_result=False,
-                            use_hessian=True,
-                            llr_tolerance=0.001)
-
-    res_test = np.array([res[k] for k in arg_names])
-
-    np.testing.assert_array_almost_equal(truth_test,
-                                         res_test, decimal=3)
-
-
-def test_mock_bestfit_scipy():
-    # Test bestfit (including hessian)
-    arg_names = ['er_rate_multiplier', 'elife']
-    mock_opt = MockScipyObjective(lf=None,
-                                  arg_names=arg_names,
-                                  fix=dict(),
-                                  autograph=True,
-                                  nan_val=float('nan'))
-
-    truths = dict(er_rate_multiplier=2.,
-                  elife=2.)
-    truth_test = np.array([truths[k] for k in arg_names])
-    mock_opt.truths = truths
-    x_guess = np.array([1., 1.])
-
-    res = mock_opt.minimize(x_guess,
-                            get_lowlevel_result=False,
-                            use_hessian=True,
-                            llr_tolerance=0.1)
-
-    res_test = np.array([res[k] for k in arg_names])
+    res = mock_objective.minimize()
+    res_test = np.array([res[k]
+                         for k in mock_objective.arg_names])
 
     np.testing.assert_array_almost_equal(truth_test,
                                          res_test, decimal=3)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -263,7 +263,6 @@ def test_set_data(xes: fd.ERSource):
     x = xes.batched_differential_rate()
     assert x.shape == (2,)
 
-
     data1 = xes.data
     data2 = pd.concat([data1.copy(),
                        data1.iloc[:1].copy()])

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -101,6 +101,11 @@ def test_simulate(xes: fd.ERSource):
     simd = xes.simulate(n_ev)
     assert len(simd) <= n_ev
 
+    # Test n_events etc. have not been changed
+    assert xes.n_events == 2
+    assert len(xes.data) == 2
+    assert xes.n_batches == 1
+
     # Test simulate with fix_truth DataFrame
     fix_truth_df = simd.iloc[:1].copy()
     simd = xes.simulate(n_ev, fix_truth=fix_truth_df)


### PR DESCRIPTION
Objective tilt
------------------
Our limit/interval search currently stops when the -2 log likelihood reaches a critical value (set by the confidence level). If there are nuisance parameters, this can be anywhere along an asymptotically elliptical likelihood contour. (Which is not good.)

The actual solution is at the extreme values of the target parameter on this contour -- since the confidence interval encloses the full contour. We can ensure we get to the extreme value of the likelihood contour by adding a tilt term to the objective:

    objective = (f(x) - f_0)^2 - w * (x - xhat) / sigma

Here:
  * f(x) is the -2 log likelihood difference from the global-bestfit likelihood. This depends on both x and any nuisance parameters.
  * f_0 the desired critical value (e.g. 1.64 to get an asymptotic 90% upper limit)
  * w a constant parametrizing the tilt amplitude
  * x the target variable (e.g. the wimp rate multiplier)
  * xhat the best-fit value of x
  * sigma a guess for the one-sigma confidence interval on x (either supplied by the user or guessed from the Hessian)

The sign of the second term must be reversed when searching for a lower limit (or lower part of a central interval).

The tilt amplitude `w` term should be configurable, but we can guess what values make sense:
  * At the extrema of the objective, `x = w / (2 * sigma * (f(x) - f0))`. 
  * If the log likelihood is parabolic, `f = 1/2 * ((x-xhat)/sigma)^2`, so we have `f(x) = 1/8 * (w/(sigma*(f-f0)))^2` at the extrema. 
  * Solving and expanding for small w, we get `f = f0 ( 1 + w^2/(8*f0^2*sigma^2) + O((w/(f0*sigma))^4)` at the minimum (there is also a maximum at `f = -w^2/(8*f0*sigma^2) + ...`). Thus, we have overshot our target value `f0` by by `w^2/(8*f0*sigma^2)`.
  * The  `w` should thus be around `\sqrt(8 T f_0) sigma`, where T is the user's absolute tolerance for error on the -2 log likelihood difference. Fortunately, we already pass T to the search, to control the minimizer.

Usually, intervals are searched for in a different way. At the extreme points on the likelihood contour, the likelihood is at a conditional maximum -- the fit cannot by improved by changing the nuisance parameters. Thus, you can find an interval by a line search (in the target parameter) over a function calling a second optimizer (ensuring the conditional maximum). This seems to be what MINOS does, see [here](http://cmd.inp.nsk.su/old/cmd2/manuals/cernlib/minuit/node14.html). Our solution should be faster, since it solves the problem in a single minimization.

... if it is correct. We did not test this at all yet!

Inference refactor
---------------------------
This PR also refactors the inference code:

External API changes:
  * `LogLikelihood.one_parameter_interval` is no more; use either `LogLikelihood.limit` or `LogLikelihood.interval`. They refer to exactly the same function, except that `limit` has `kind='upper'` and `central` has `kind='central'` as default. So you can still request interval(kind='upper') if you don't want to type `limit`.
  * If you pass a `guess` to `limit` it must be a dictionary (just like before #59) or two-tuple of dictionaries (for `kind='central'`). This is necessary to allow the user to guess the position in the full n-d parameter space. You do not have to include all variables though. If you omit a nuisance parameter, it will be guessed equal to the bestfit. If you omit the target parameter, it will be guessed based on the asymptotic approximation and the Hessian-derived errors.
  * If you want to pass arguments to the optimizers of `bestfit`, `interval` and `limit`, you have to pass them through the `optimizer_kwargs=dict(...)`. These functions take many keyword arguments, and it is easy to mistype them: you'd prefer this to give an error immediately.

Internal API changes:
  * The Objectives now only take arguments to __init__; `minimize` takes no arguments.
  * The `inference.one_parameter_interval` is gone; its work is done either in `IntervalObjective.__init__`.
  * Much code from `LogLikelihood.bestfit` ais now in `Objective.__init__`.
  * The getter functions `inference.get_bestfit_objective` etc. are gone. If the user passes an invalid optimizer option, they will now get e.g.
```
>>> lf.bestfit(optimizer='magic')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/aalbers/software/flamedisx/flamedisx/likelihood.py", line 380, in bestfit
    opt = fd.SUPPORTED_OPTIMIZERS[optimizer]
KeyError: 'magic'
```
which seems clear enough.