### PR TITLE
Trace log likelihood, then no more tensorflow

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -357,7 +357,10 @@ class IntervalObjective(Objective):
             dx_1 = (2 * dy) ** 0.5 * abs(self.sigma_guess)
 
             # ... or the slope (for boundary solutions)
-            dx_2 = abs(dy / self.bestfit_tp_slope)
+            if self.bestfit_tp_slope == 0:
+                dx_2 = float('inf')
+            else:
+                dx_2 = abs(dy / self.bestfit_tp_slope)
 
             # Take the smaller of the two and add it on the correct side
             # TODO: Is the best one always smallest? Don't know...

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -237,7 +237,7 @@ class TensorFlowObjective(Objective):
         res = tfp.optimizer.bfgs_minimize(
             self.fun_and_grad,
             initial_position=x_guess,
-            initial_inverse_hessian_estimate=inv_hess,
+            initial_inverse_hessian_estimate=fd.np_to_tf(inv_hess),
             **kwargs)
         ret, res = self._lowlevel_shortcut(res)
         if ret:
@@ -248,6 +248,9 @@ class TensorFlowObjective(Objective):
         res = res.position
         res = {k: res[i] for i, k in enumerate(self.arg_names)}
         return {**res, **self.fix}
+
+    def fun_and_grad(self, x):
+        return fd.np_to_tf(super().fun_and_grad(x))
 
 
 class MinuitObjective(Objective):

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -219,6 +219,7 @@ class TensorFlowObjective(Objective):
                 omit_grads=tuple(self.fix.keys()))
             # Explicitly symmetrize the matrix
             inv_hess = fd.symmetrize_matrix(inv_hess)
+            inv_hess = fd.np_to_tf(inv_hess)
         else:
             inv_hess = None
 
@@ -237,7 +238,7 @@ class TensorFlowObjective(Objective):
         res = tfp.optimizer.bfgs_minimize(
             self.fun_and_grad,
             initial_position=x_guess,
-            initial_inverse_hessian_estimate=fd.np_to_tf(inv_hess),
+            initial_inverse_hessian_estimate=inv_hess,
             **kwargs)
         ret, res = self._lowlevel_shortcut(res)
         if ret:

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -126,9 +126,9 @@ class Objective:
         ll, grad = self._inner_fun_and_grad(params)
 
         # Check NaNs
-        if tf.math.is_nan(ll):
-            tf.print(f"Objective at {x} is Nan!")
-            ll = tf.constant(self.nan_val, dtype=tf.float32)
+        if np.isnan(ll):
+            print(f"Objective at {x} is Nan!")
+            ll = self.nan_val
 
         if self.return_history:
             self._history.append(dict(params=params, ll=ll, grad=grad))
@@ -416,10 +416,7 @@ class IntervalObjective(Objective):
         # where our likelihood equals the target amplitude.
         fun += - self.direction * self.tilt * x_norm
         extra_grad = - self.direction * self.tilt / self.sigma_guess
-        grad += tf.where(
-            tf.equal(self.arg_names, self.target_parameter),
-            extra_grad,
-            tf.constant(0., dtype=fd.float_type()))
+        grad[self.arg_names.index(self.target_parameter)] += extra_grad
 
         return fun + self._offset, grad
 

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -598,7 +598,6 @@ class LogLikelihood:
         # Get second order derivatives of likelihood at params
         _, _, grad2_ll = self.log_likelihood(**params,
                                              omit_grads=omit_grads,
-                                             autograph=False,
                                              second_order=True)
 
         return tf.linalg.inv(-2 * grad2_ll)

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -109,11 +109,6 @@ class LogLikelihood:
             sname: sclass.find_defaults()[2]
             for sname, sclass in self.sources.items()}
 
-        if data is not None:
-            # Use smaller batch size if data is tiny
-            # (have to do it here, cannot be changed after initing source)
-            batch_size = min(len(data), batch_size)
-
         # Create sources
         self.sources = {
             sname: sclass(data=None,

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -259,9 +259,9 @@ class LogLikelihood:
             for i_batch in tf.range(n_batches, dtype=fd.int_type()):
                 v = f(i_batch,
                       dsetname=dsetname,
-                      omit_grads=omit_grads,
                       data_tensor=self.data_tensors[dsetname],
                       batch_info=self.batch_info,
+                      omit_grads=omit_grads,
                       **params)
                 ll += v[0]
                 llgrad += v[1]
@@ -325,9 +325,8 @@ class LogLikelihood:
         grad = t.gradient(ll, grad_par_list)
         return ll, tf.stack(grad)
 
-    @tf.function
-    def _log_likelihood_grad2(self, i_batch, dsetname, data_tensor,
-                              batch_info, omit_grads=tuple(), **params):
+    def _log_likelihood_grad2(self, i_batch, dsetname, data_tensor, batch_info,
+                              omit_grads=tuple(), **params):
         grad_par_list = [x for k, x in params.items()
                          if k not in omit_grads]
         with tf.GradientTape(persistent=True) as t2:

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -196,7 +196,8 @@ class LogLikelihood:
 
         self.column_indices = dict()
         for dsetname in self.dsetnames:
-            stop_idx = np.cumsum([len(self.sources[sname].cols_to_cache)
+            # Do not use len(cols_to_cache), some sources have extra columns...
+            stop_idx = np.cumsum([self.sources[sname].data_tensor.shape[2]
                                   for sname in self.sources_in_dset[dsetname]])
             self.column_indices[dsetname] = np.transpose([
                 np.concatenate([[0], stop_idx[:-1]]),

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -143,11 +143,15 @@ class Source:
                     v, dtype=fd.float_type())
 
     def set_data(self,
-                 data,
+                 data=None,
                  data_is_annotated=False,
                  _skip_tf_init=False,
                  _skip_bounds_computation=False,
                  **params):
+        if data is None:
+            self.data = self.n_batches = self.n_padding = None
+            return
+
         self.data = data
         del data
 

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -148,14 +148,13 @@ class Source:
                  _skip_tf_init=False,
                  _skip_bounds_computation=False,
                  **params):
+        self.set_defaults(**params)
+
         if data is None:
             self.data = self.n_batches = self.n_padding = None
             return
-
         self.data = data
         del data
-
-        self.set_defaults(**params)
 
         # Annotate requests n_events, currently no padding
         self.n_padding = 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -49,30 +49,6 @@ def test_one_parameter_interval(xes):
                   confidence_level=0.9, kind='upper')
 
 
-def test_bestfit_tf(xes):
-    # Test bestfit (including hessian)
-    lf = fd.LogLikelihood(
-        sources=dict(er=xes.__class__),
-        elife=(100e3, 500e3, 5),
-        free_rates='er',
-        data=xes.data)
-
-    guess = lf.guess()
-    # Set reasonable rate
-    # Evaluate the likelihood curve around the minimum
-    xs_er = np.linspace(0.001, 0.004, 20)  # ER source range
-    xs_nr = np.linspace(0.04, 0.1, 20)  # NR source range
-    xs = list(xs_er) + list(xs_nr)
-    ys = np.array([-lf(er_rate_multiplier=x) for x in xs])
-    guess['er_rate_multiplier'] = xs[np.argmin(ys)]
-    assert len(guess) == 2
-
-    bestfit = lf.bestfit(guess, optimizer='tfp', use_hessian=True)
-    assert isinstance(bestfit, dict)
-    assert len(bestfit) == 2
-    assert bestfit['er_rate_multiplier'].dtype == np.float32
-
-
 def test_bestfit_minuit(xes):
     # Test bestfit (including hessian)
     lf = fd.LogLikelihood(

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -42,12 +42,10 @@ def test_inference(xes: fd.ERSource):
         elife=(100e3, 500e3, 5),
         data=xes.data)
 
-    ##
-    # Test non-autograph version
-    ##
+    # Test single-batch likelihood
     x, x_grad = lf._log_likelihood(i_batch=tf.constant(0),
                                    dsetname=DEFAULT_DSETNAME,
-                                   autograph=False,
+                                   data_tensor=lf.data_tensors[DEFAULT_DSETNAME],
                                    batch_info=lf.batch_info,
                                    elife=tf.constant(200e3))
     assert isinstance(x, tf.Tensor)
@@ -61,18 +59,16 @@ def test_inference(xes: fd.ERSource):
     # Test a different parameter gives a different likelihood
     x2, x2_grad = lf._log_likelihood(i_batch=tf.constant(0),
                                      dsetname=DEFAULT_DSETNAME,
-                                     autograph=False,
+                                     data_tensor=lf.data_tensors[DEFAULT_DSETNAME],
                                      batch_info=lf.batch_info,
                                      elife=tf.constant(300e3))
     assert (x - x2).numpy() != 0
     assert (x_grad - x2_grad).numpy().sum() !=0
 
-    ##
     # Test batching
-    # ##
-    l1 = lf.log_likelihood(autograph=False)
-    l2 = lf(autograph=False)
-    lf.log_likelihood(elife=tf.constant(200e3), autograph=False)
+    l1 = lf.log_likelihood()
+    l2 = lf()
+    lf.log_likelihood(elife=tf.constant(200e3))
 
 
 def test_multisource(xes: fd.ERSource):

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -86,7 +86,7 @@ def test_multisource(xes: fd.ERSource):
     # Prevent jitter from mu interpolator simulation to fail test
     itp = lf.mu_itps['er']
     lf2.mu_itps = dict(er=itp, er2=itp)
-    assert lf2.log_likelihood()[0].numpy() == l1[0].numpy()
+    assert lf2.log_likelihood()[0] == l1[0]
 
 
 def test_multisource_er_nr(xes: fd.ERSource):
@@ -296,12 +296,11 @@ def test_hessian(xes: fd.ERSource):
     assert len(guess) == 2
 
     inv_hess = lf.inverse_hessian(guess)
-    inv_hess_np = inv_hess.numpy()
-    assert inv_hess_np.shape == (2, 2)
-    assert inv_hess.dtype == fd.float_type()
+    assert inv_hess.shape == (2, 2)
+    assert inv_hess.dtype == np.float32
     # Check symmetry of hessian
     # The hessian is explicitly symmetrized before being passed to
     # the optimizer in bestfit
-    a = inv_hess_np[0, 1]
-    b = inv_hess_np[1, 0]
+    a = inv_hess[0, 1]
+    b = inv_hess[1, 0]
     assert abs(a - b)/(a+b) < 1e-3

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -48,6 +48,7 @@ def test_inference(xes: fd.ERSource):
     x, x_grad = lf._log_likelihood(i_batch=tf.constant(0),
                                    dsetname=DEFAULT_DSETNAME,
                                    autograph=False,
+                                   batch_info=lf.batch_info,
                                    elife=tf.constant(200e3))
     assert isinstance(x, tf.Tensor)
     assert x.dtype == fd.float_type()
@@ -61,6 +62,7 @@ def test_inference(xes: fd.ERSource):
     x2, x2_grad = lf._log_likelihood(i_batch=tf.constant(0),
                                      dsetname=DEFAULT_DSETNAME,
                                      autograph=False,
+                                     batch_info=lf.batch_info,
                                      elife=tf.constant(300e3))
     assert (x - x2).numpy() != 0
     assert (x_grad - x2_grad).numpy().sum() !=0

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -189,7 +189,7 @@ def test_multi_dset(xes: fd.ERSource):
 
     ll2 = lf2()
 
-    np.testing.assert_almost_equal(2 * ll1, ll2)
+    np.testing.assert_almost_equal(2 * ll1, ll2, decimal=2)
 
 
 def test_simulate(xes):

--- a/tests/test_mock_inference.py
+++ b/tests/test_mock_inference.py
@@ -10,7 +10,8 @@ arg_names = ['er_rate_multplier', 'elife']
 truth_test = np.array([2., 3.])
 
 
-@pytest.fixture(params=fd.SUPPORTED_OPTIMIZERS.values())
+@pytest.fixture(params=[x for x in fd.SUPPORTED_OPTIMIZERS.values()
+                        if x != fd.inference.TensorFlowObjective])
 def mock_objective(request):
 
     class MockObjective(request.param):
@@ -29,12 +30,6 @@ def mock_objective(request):
             ll_grad_dict = {k: 0 for k in grads_to_return}
 
             for k, v in params.items():
-                # TODO: investigate and remove hack
-                try:
-                    v = v.numpy()
-                except AttributeError:
-                    pass
-
                 if k.endswith('_rate_multiplier') and v <= 0.:
                     ll = float('nan')
                     ll_grad = [float('nan')] * n_grads
@@ -42,8 +37,7 @@ def mock_objective(request):
                 # Add parabola
                 ll += (v - self.truths[k]) ** 2
                 ll_grad_dict[k] += 2 * (v - self.truths[k])
-            return (tf.constant(ll, dtype=fd.float_type()),
-                    tf.constant(list(ll_grad_dict.values()), dtype=fd.float_type()))
+            return ll, np.array(list(ll_grad_dict.values()))
 
     truths = {k: truth_test[i] for i, k in enumerate(arg_names)}
     guess = {k: 1. for k in arg_names}

--- a/tests/test_mock_inference.py
+++ b/tests/test_mock_inference.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 
 import flamedisx as fd
 
@@ -10,8 +9,7 @@ arg_names = ['er_rate_multplier', 'elife']
 truth_test = np.array([2., 3.])
 
 
-@pytest.fixture(params=[x for x in fd.SUPPORTED_OPTIMIZERS.values()
-                        if x != fd.inference.TensorFlowObjective])
+@pytest.fixture(params=list(fd.SUPPORTED_OPTIMIZERS.values()))
 def mock_objective(request):
 
     class MockObjective(request.param):


### PR DESCRIPTION
This:
  * Enables autograph mode for the `_log_likelihood` function, which computes the likelihood of a single batch and dataset (for all sources in that dataset).
  * Avoids using tensorflow in higher-level functions, i.e. convert to numpy immediately after `_log_likelihood`.
  * Removes the test for the tensorflow-probability minimizer. 

The main reason for this change is performance: eager tensorflow has a much higher per-computation overhead  than autograph tensorflow or numpy, but the computations after _log_likelihood are all small and on tiny bits of data -- both the sum over events and that over sources have already happened at that point.

For simple likelihoods made of ColumnSources, i.e. where the likelihood per event is precomputed, the eager-mode computation made up the vast majority of the computational work. For a simple test, I computed 11 limits of different CLs with a ColumnSource likelihood on my laptop CPU:
  * This took ~89 seconds in current master and ~2.8 seconds after this change (~30x speedup).
  * If guess sigma_guess are not passed in, these have to be derived from the Hessian, which is still an eager-mode computation (it still gives NaNs in autograph mode). Then the test takes ~94 seconds in the current master and ~4.7 seconds after this change (still a ~20x speedup).

To avoid #53, we pass the data tensors and batching info as function arguments. This means the likelihood does not have to be retraced after each `set_data`. @pelssers already implemented a test to check that this, in fact, works.

The data tensors are concatenated (along the second axis, i.e. columns_to_cache) into one super data tensor for each dataset. This avoids having to pass a variable-length list into the autograph functions, which would probably trigger retracing.

The tensorflow-probability minimizer was not used in practice since it did not support bounds; it _might_ still work after this change (at least it gets to OptimizerFailure) but since we now convert to numpy before hitting the optimizer there seems little point in converting back.
