### PR TITLE
cS1 cut and special_data_method cleanup

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -364,6 +364,9 @@ class LXeSource(fd.Source):
         """
         ndet = self.domain(quanta_type + '_detected', data_tensor)
 
+        observed = self._fetch(
+            signal_name[quanta_type], data_tensor=data_tensor)
+
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',
                                 data_tensor=data_tensor, ptensor=ptensor)

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -26,8 +26,6 @@ special_data_methods = [
     'p_electron_fluctuation',
     'electron_acceptance',
     'photon_acceptance',
-    's1_acceptance',
-    's2_acceptance',
     'penning_quenching_eff'
 ]
 
@@ -366,19 +364,19 @@ class LXeSource(fd.Source):
         ndet = self.domain(quanta_type + '_detected', data_tensor)
 
         observed = self._fetch(
-            signal_name[quanta_type], data_tensor=data_tensor)[:, o]
+            signal_name[quanta_type], data_tensor=data_tensor)
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',
-                                data_tensor=data_tensor, ptensor=ptensor)[:, o]
+                                data_tensor=data_tensor, ptensor=ptensor)
         std_per_q = self.gimme(quanta_type + '_gain_std',
-                               data_tensor=data_tensor, ptensor=ptensor)[:, o]
+                               data_tensor=data_tensor, ptensor=ptensor)
 
         if quanta_type == 'photon':
             mean, std = self.dpe_mean_std(
                 ndet=ndet,
                 p_dpe=self.gimme('double_pe_fraction',
-                                 data_tensor=data_tensor, ptensor=ptensor)[:, o],
+                                 data_tensor=data_tensor, ptensor=ptensor),
                 mean_per_q=mean_per_q,
                 std_per_q=std_per_q)
         else:
@@ -392,9 +390,8 @@ class LXeSource(fd.Source):
 
         # Add detection/selection efficiency
         result *= self.gimme(signal_name[quanta_type] + '_acceptance',
-                             bonus_arg=observed,
                              data_tensor=data_tensor, ptensor=ptensor)
-        return result
+        return result[:, o]
 
     @staticmethod
     def dpe_mean_std(ndet, p_dpe, mean_per_q, std_per_q):

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -362,7 +362,7 @@ class LXeSource(fd.Source):
         ndet = self.domain(quanta_type + '_detected', data_tensor)
 
         observed = self._fetch(
-            signal_name[quanta_type], data_tensor=data_tensor)
+            signal_name[quanta_type], data_tensor=data_tensor)[:, o]
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',
@@ -388,8 +388,8 @@ class LXeSource(fd.Source):
 
         # Add detection/selection efficiency
         result *= self.gimme(signal_name[quanta_type] + '_acceptance',
-                             data_tensor=data_tensor, ptensor=ptensor)
-        return result[:, o]
+                             data_tensor=data_tensor, ptensor=ptensor)[:, o]
+        return result
 
     @staticmethod
     def dpe_mean_std(ndet, p_dpe, mean_per_q, std_per_q):

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -31,8 +31,9 @@ special_data_methods = [
 
 data_methods = (
     special_data_methods
-    + ['energy_spectrum', 'work', 'double_pe_fraction'])
-hidden_vars_per_quanta = 'detection_eff gain_mean gain_std'.split()
+    + ['energy_spectrum', 'work', 'double_pe_fraction',
+       's1_acceptance', 's2_acceptance'])
+hidden_vars_per_quanta = ['detection_eff', 'gain_mean', 'gain_std']
 for _qn in quanta_types:
     data_methods += [_qn + '_' + x for x in hidden_vars_per_quanta]
 
@@ -362,9 +363,6 @@ class LXeSource(fd.Source):
         for different number of detected quanta.
         """
         ndet = self.domain(quanta_type + '_detected', data_tensor)
-
-        observed = self._fetch(
-            signal_name[quanta_type], data_tensor=data_tensor)
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -591,7 +591,7 @@ class LXeSource(fd.Source):
         for q in quanta_types:
             acceptance *= gimme(q + '_acceptance', d[q + '_detected'].values)
             sn = signal_name[q]
-            acceptance *= gimme(sn + '_acceptance', d[sn].values)
+            acceptance *= gimme(sn + '_acceptance')
         return d.iloc[np.random.rand(len(d)) < acceptance].copy()
 
     def mu_before_efficiencies(self, **params):

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -49,9 +49,6 @@ class LXeSource(fd.Source):
         'photon_produced',
         'electron_produced')
 
-    def extra_needed_columns(self):
-        return super().extra_needed_columns() + ['s1', 's2']
-
     # Whether or not to simulate overdispersion in electron/photon split
     # (e.g. due to non-binomial recombination fluctuation)
     do_pel_fluct: bool

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -362,7 +362,7 @@ class LXeSource(fd.Source):
         ndet = self.domain(quanta_type + '_detected', data_tensor)
 
         observed = self._fetch(
-            signal_name[quanta_type], data_tensor=data_tensor)[:, o]
+            signal_name[quanta_type], data_tensor=data_tensor)
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',
@@ -384,7 +384,7 @@ class LXeSource(fd.Source):
         # add offset to std to avoid NaNs from norm.pdf if std = 0
         result = tfp.distributions.Normal(
                 loc=mean, scale=std + 1e-10
-            ).prob(observed)
+            ).prob(observed[:, o])
 
         # Add detection/selection efficiency
         result *= self.gimme(signal_name[quanta_type] + '_acceptance',

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -366,15 +366,15 @@ class LXeSource(fd.Source):
 
         # Lookup signal gain mean and std per detected quanta
         mean_per_q = self.gimme(quanta_type + '_gain_mean',
-                                data_tensor=data_tensor, ptensor=ptensor)
+                                data_tensor=data_tensor, ptensor=ptensor)[:, o]
         std_per_q = self.gimme(quanta_type + '_gain_std',
-                               data_tensor=data_tensor, ptensor=ptensor)
+                               data_tensor=data_tensor, ptensor=ptensor)[:, o]
 
         if quanta_type == 'photon':
             mean, std = self.dpe_mean_std(
                 ndet=ndet,
                 p_dpe=self.gimme('double_pe_fraction',
-                                 data_tensor=data_tensor, ptensor=ptensor),
+                                 data_tensor=data_tensor, ptensor=ptensor)[:, o],
                 mean_per_q=mean_per_q,
                 std_per_q=std_per_q)
         else:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -107,6 +107,15 @@ class Source:
         ctc += [x + '_min' for x in self.inner_dimensions]  # Needed in domain
         ctc = [x for x in ctc if x not in self.ignore_columns()]
         self.cols_to_cache = ctc
+
+        # Check for duplicate columns and give error
+        _seen = set()
+        for x in self.cols_to_cache:
+            if x in _seen:
+                raise RuntimeError(
+                    f"Column {x} requested twice for data_tensor!")
+            _seen.add(x)
+
         self.name_id = fd.index_lookup_dict(ctc)
 
         self.set_defaults(**params)

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -99,6 +99,7 @@ class SR0Source:
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_relative_ly
 
+    @staticmethod
     def s1_acceptance(s1, photon_detection_eff, photon_gain_mean):
         # Both cS1 and S1 acceptance
         cs1 = (0.142 / (1 + 0.219)) * s1 / (

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -99,11 +99,10 @@ class SR0Source:
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_relative_ly
 
-    @staticmethod
-    def s1_acceptance(s1, photon_detection_eff, photon_gain_mean):
+    def s1_acceptance(self, s1, photon_detection_eff):
         # Both cS1 and S1 acceptance
         cs1 = (0.142 / (1 + 0.219)) * s1 / (
-            photon_detection_eff * photon_gain_mean)
+            photon_detection_eff * self.photon_gain_mean)
         return tf.where((s1 < 2) | (s1 > 70) | (cs1 < 2),
                         tf.zeros_like(s1, dtype=fd.float_type()),
                         tf.ones_like(s1, dtype=fd.float_type()))

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -100,9 +100,10 @@ class SR0Source:
         return mean_eff * s1_relative_ly
 
     @staticmethod
-    def s1_acceptance(s1, photon_detection_eff, photon_gain_mean):
+    def s1_acceptance(s1, photon_detection_eff, photon_gain_mean,
+                      mean_eff=0.142 / (1 + 0.219)):
         # Both cS1 and S1 acceptance
-        cs1 = (0.142 / (1 + 0.219)) * s1 / (
+        cs1 = mean_eff * s1 / (
             photon_detection_eff * photon_gain_mean)
         return tf.where((s1 < 2) | (s1 > 70) | (cs1 < 2),
                         tf.zeros_like(s1, dtype=fd.float_type()),

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -99,10 +99,11 @@ class SR0Source:
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_relative_ly
 
-    def s1_acceptance(self, s1, photon_detection_eff):
+    @staticmethod
+    def s1_acceptance(s1, photon_detection_eff, photon_gain_mean):
         # Both cS1 and S1 acceptance
         cs1 = (0.142 / (1 + 0.219)) * s1 / (
-            photon_detection_eff * self.photon_gain_mean)
+            photon_detection_eff * photon_gain_mean)
         return tf.where((s1 < 2) | (s1 > 70) | (cs1 < 2),
                         tf.zeros_like(s1, dtype=fd.float_type()),
                         tf.ones_like(s1, dtype=fd.float_type()))

--- a/flamedisx/x1t_sr0.py
+++ b/flamedisx/x1t_sr0.py
@@ -99,6 +99,14 @@ class SR0Source:
                              mean_eff=0.142 / (1 + 0.219)):
         return mean_eff * s1_relative_ly
 
+    def s1_acceptance(s1, photon_detection_eff, photon_gain_mean):
+        # Both cS1 and S1 acceptance
+        cs1 = (0.142 / (1 + 0.219)) * s1 / (
+            photon_detection_eff * photon_gain_mean)
+        return tf.where((s1 < 2) | (s1 > 70) | (cs1 < 2),
+                        tf.zeros_like(s1, dtype=fd.float_type()),
+                        tf.ones_like(s1, dtype=fd.float_type()))
+
 
 @export
 class SR0ERSource(SR0Source, fd.ERSource):


### PR DESCRIPTION
This implements a cut on cS1 for SR0 sources to remove an artifact seen when comparing the differential rate of a template based cS1, cS2 method compared to flamedisx.
This is necessary because at very low cS1 the number of detected events drops very steeply and the finite binning of the template doesn't accurately reproduce the differential rate at these energies.
We cannot place a hard cut on cS1 since it will remove events and give an incorrect normalization of the differential rate. However since cS1 is a function of S1, photon gain and photon detection efficiency we can combine it with the s1 acceptance calculation, this is done in `x1t_sr0.py`.

Secondly we no longer need `s1_acceptance` and `s2_acceptance` to be `special_data_methods` since we can put `s1` and `s2` in the data tensor. This means that we don't have to add the `s1` and `s2` columns manually anymore and a test that we don't add duplicate columns by accident has been added. (Having duplicate columns leads to a bug in the `WIMPSource` where we combine the energy spectrum with the data tensor).

Finally some tensor broadcasting has been moved in `detector_response` which may or may not make the function more readable.

**Edit:**
I've just rerun the sensitivity notebook for a 15GeV WIMP. Below are the before and after comparisons showing that indeed the artifact is now gone.

Before (no cS1 cut):
![without_cs1_cut](https://user-images.githubusercontent.com/8984694/73693261-2a02e580-46d6-11ea-8782-9e8bb639a160.png)

After (with cS1 cut):
![with_cs1_cut](https://user-images.githubusercontent.com/8984694/73693301-3d15b580-46d6-11ea-852e-340f80f7e87d.png)
