### PR TITLE
FV specification

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -95,9 +95,9 @@ class LXeSource(fd.Source):
         super().add_extra_columns(d)
         if self.spatial_rate_hist is not None:
             # Setup tensor of histogram for lookup
-            positions = self.data[self.spatial_rate_hist_dims].values.T
+            positions = d[self.spatial_rate_hist_dims].values.T
             v = self.spatial_rate_hist.lookup(*positions)
-            d['spatial_rate_multiplier'] = v.reshape([self.n_batches, -1])
+            d['spatial_rate_multiplier'] = v
         else:
             d['spatial_rate_multiplier'] = 1.
 

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -81,10 +81,6 @@ class LXeSource(fd.Source):
                 " 'tpc_length', these are deprecated. Use 'fv_radius',"
                 " 'fv_high' and 'fv_low' to denote the boundaries of the"
                 " detector.")
-            # Try and set the correct fv boundaries anyway
-            self.fv_radius = self.tpc_radius
-            self.fv_high = 0
-            self.fv_low = -self.tpc_length
 
         assert self.fv_low < self.fv_high, \
             f"fv_low ({self.fv_low}) not less then fv_high ({self.fv_high})"
@@ -248,7 +244,6 @@ class LXeSource(fd.Source):
     def random_truth_observables(self, n_events):
         """Return dictionary with x, y, z, r, theta, drift_time
         and event_time randomly drawn.
-        S1 and S2 placeholder values are added for set_data.
         Takes into account spatial rate multiplier of the source.
         """
         data = dict()

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -279,7 +279,7 @@ class LXeSource(fd.Source):
         data['event_time'] = np.random.uniform(
             self.t_start.value,
             self.t_stop.value,
-            size=n_events).astype('float32')
+            size=n_events)
         return data
 
     ##

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -252,10 +252,6 @@ class LXeSource(fd.Source):
         Takes into account spatial rate multiplier of the source.
         """
         data = dict()
-        # Add fake s1, s2 necessary for set_data to succeed
-        # TODO: check if we still need this...
-        data['s1'] = 1
-        data['s2'] = 100
 
         if self.spatial_rate_hist is None:
             # Draw uniform position

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -47,11 +47,20 @@ def xes(request):
         z = np.linspace(-97.6, 0, nbins + 1)
         theta = np.linspace(0, 2 * np.pi, nbins + 1)
 
+        # Construct PDF histogram
         h = Histdd(bins=[r, theta, z], axis_names=['r', 'theta', 'z'])
         h.histogram = np.ones((nbins, nbins, nbins))
 
+        # Calculate bin volumes for cylindrical coords (r dr dtheta)
+        r_c, _, _ = h.bin_centers()
+        bin_volumes = h.bin_volumes() * r_c[:, np.newaxis, np.newaxis]
+
+        # Convert to events per bin histogram
+        h.histogram *= bin_volumes
+
         class ERSpatial(fd.ERSource):
-            spatial_hist = h
+            spatial_rate_hist = h
+            spatial_rate_bin_volumes = bin_volumes
 
         x = ERSpatial(data.copy(), batch_size=2, max_sigma=8)
     return x


### PR DESCRIPTION
This changes the specification of the TPC dimensions in `LXeSource` to use a simple cylindrical fiducial volume instead. By default the behaviour is the same since the whole TPC is set a FV. Using `fv_radius` the maximum radius of events is set. `fv_high` and `fv_low` set the maximum and minimum depth respectively.
Setting the old `tpc_radius` and `tpc_length` parameters now raises a `DeprecationWarning`

An unnecessary reshape in `add_extra_columns` has been removed.

S1,S2 placeholder values have been removed from `random_truth_observables`, they are no longer needed for `set_data` to work. This was originally needed for bounds computation.

Lastly when drawing `event_time` values (which are O(10^18) integers) don't convert them to floats to preserve precision (they will eventually end up in the data tensor as float types anyway, but keep them as integers for as long as possible (and for simulate)).