### PR TITLE
Simulator optimizations

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -518,10 +518,8 @@ class LXeSource(fd.Source):
                 # For detected quanta the MLE is quite accurate
                 # (since fluctuations are tiny)
                 # so let's just use the relative error on the MLE
-                d[qn + '_detected_' + bound] = stats.norm.ppf(
-                    stats.norm.cdf(sign * self.max_sigma),
-                    loc=n,
-                    scale=scale,
+                d[qn + '_detected_' + bound] = (
+                    (n - sign * self.max_sigma) / scale
                 ).round().clip(*self._q_det_clip_range(qn)).astype(np.int)
 
                 # For produced quanta, it is trickier, since the number
@@ -529,10 +527,10 @@ class LXeSource(fd.Source):
                 # TODO: where did this derivation come from again?
                 # TODO: maybe do a second bound based on CES
                 q = 1 / eff
-                d[qn + '_produced_' + bound] = stats.norm.ppf(
-                    stats.norm.cdf(sign * self.max_sigma),
-                    loc=n_prod_mle,
-                    scale=(q + (q**2 + 4 * n_prod_mle * q)**0.5)/2
+                _loc = n_prod_mle
+                _std = (q + (q**2 + 4 * n_prod_mle * q)**0.5)/2
+                d[qn + '_produced_' + bound] = (
+                    (_loc - sign * self.max_sigma) / _std
                 ).round().clip(*self._q_det_clip_range(qn)).astype(np.int)
 
             # Finally, round the detected MLEs
@@ -559,9 +557,9 @@ class LXeSource(fd.Source):
 
         if self.do_pel_fluct:
             d['p_el_fluct'] = gimme('p_electron_fluctuation', d['nq'].values)
-            d['p_el_fluct'] = tf.clip_by_value(d['p_el_fluct'],
-                                               fd.MIN_FLUCTUATION_P,
-                                               1.)
+            d['p_el_fluct'] = np.clip(d['p_el_fluct'].values,
+                                      fd.MIN_FLUCTUATION_P,
+                                      1.)
             d['p_el_actual'] = 1. - stats.beta.rvs(
                 *fd.beta_params(1. - d['p_el_mean'], d['p_el_fluct']))
         else:

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -519,7 +519,7 @@ class LXeSource(fd.Source):
                 # (since fluctuations are tiny)
                 # so let's just use the relative error on the MLE
                 d[qn + '_detected_' + bound] = (
-                    (n - sign * self.max_sigma) / scale
+                    n + sign * self.max_sigma * scale
                 ).round().clip(*self._q_det_clip_range(qn)).astype(np.int)
 
                 # For produced quanta, it is trickier, since the number
@@ -530,7 +530,7 @@ class LXeSource(fd.Source):
                 _loc = n_prod_mle
                 _std = (q + (q**2 + 4 * n_prod_mle * q)**0.5)/2
                 d[qn + '_produced_' + bound] = (
-                    (_loc - sign * self.max_sigma) / _std
+                    _loc + sign * self.max_sigma * _std
                 ).round().clip(*self._q_det_clip_range(qn)).astype(np.int)
 
             # Finally, round the detected MLEs

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -201,7 +201,8 @@ class Source:
 
     @contextmanager
     def _set_temporarily(self, data, **kwargs):
-        """Set data and/or defaults temporarily"""
+        """Set data and/or defaults temporarily, without affecting the
+        data tensor state"""
         if data is None:
             raise ValueError("No point in setting data = None temporarily")
         old_defaults = self.defaults
@@ -218,7 +219,10 @@ class Source:
         finally:
             self.defaults = old_defaults
             if old_data is not None:
-                self.set_data(old_data, _skip_tf_init=True)
+                self.set_data(
+                    old_data,
+                    data_is_annotated=True,
+                    _skip_tf_init=True)
 
     def annotate_data(self, data, _skip_bounds_computation=False, **params):
         """Add columns to data with inference information"""


### PR DESCRIPTION
This improves the simulator speed by a factor ~2:
  * Do not call annotate when restoring old data in set_temporarily
  * Remove redundant ppf(cdf(x)) to just x calls in the bound estimation -- since ppf(cdf(x)) is just the identity.
  * Remove unnecessary use of tensorflow's `clip_by_value` inside annotate. Since we're in numpy/pandas land, `np.clip` is faster.