### PR TITLE
Add sanity checks on the input data and guess

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -440,6 +440,16 @@ class LXeSource(fd.Source):
                 else self.min_s2_electrons_detected,
                 None)
 
+    def _check_data(self):
+        super()._check_data()
+        for sn in signal_name.values():
+            s_acc = self.gimme(sn + '_acceptance',
+                               data_tensor=None, ptensor=None, numpy_out=True)
+            if np.any(s_acc <= 0):
+                raise ValueError(f"Found event with non-positive {sn} "
+                                 f"acceptance: did you apply and configure "
+                                 "your cuts correctly?")
+
     def _annotate(self, _skip_bounds_computation=False):
         d = self.data
 

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -75,7 +75,6 @@ class LXeSource(fd.Source):
     spatial_rate_hist = None
     spatial_rate_bin_volumes = None
 
-
     def __init__(self, *args, **kwargs):
         # Deprecate tpc_radius and tpc_length
         if hasattr(self, 'tpc_radius') or hasattr(self, 'tpc_length'):
@@ -459,10 +458,16 @@ class LXeSource(fd.Source):
             for parname in hidden_vars_per_quanta:
                 fname = qn + '_' + parname
                 try:
-                    d[fname] = self.gimme(fname, data_tensor=None, ptensor=None, numpy_out=True)
+                    d[fname] = self.gimme(fname, data_tensor=None,
+                                          ptensor=None, numpy_out=True)
                 except Exception:
                     print(fname)
                     raise
+            if np.any(d[qn + '_detection_eff'].values <= 0):
+                raise ValueError(f"Found event with non-positive {qn} "
+                                 "detection efficiency: did you apply and "
+                                 "configure your cuts correctly?")
+
         d['double_pe_fraction'] = self.gimme('double_pe_fraction',
                                              data_tensor=None, ptensor=None,
                                              numpy_out=True)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -187,8 +187,18 @@ class Source:
             self._annotate(_skip_bounds_computation=_skip_bounds_computation)
 
         if not _skip_tf_init:
+            self._check_data()
             self._populate_tensor_cache()
             self._calculate_dimsizes()
+
+    def _check_data(self):
+        """Do any final checks on the self.data dataframe,
+        before passing it on to the tensorflow layer.
+        """
+        for column in self.cols_to_cache:
+            if column not in self.data.columns:
+                raise ValueError(f"Data lacks required column {column}; "
+                                 f"did annotation happen correctly?")
 
     def _populate_tensor_cache(self):
 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -218,7 +218,7 @@ def test_simulate_column(xes):
 def test_set_data(xes: fd.ERSource):
     data1 = xes.data
     data2 = pd.concat([data1.copy(), data1.iloc[:1].copy()])
-    data2['s1'] *= 1.3
+    data2['s1'] *= 0.7
 
     data3 = pd.concat([data2, data2.iloc[:1]])
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -275,7 +275,7 @@ def test_set_data(xes: fd.ERSource):
     data1 = xes.data
     data2 = pd.concat([data1.copy(),
                        data1.iloc[:1].copy()])
-    data2['s1'] *= 1.3
+    data2['s1'] *= 0.9
     data3 = pd.concat([data2, data2.iloc[:1]])
 
     # Setting temporarily


### PR DESCRIPTION
This lets flamedisx check that the likelihood has a finite value at the guess, and checks the inferred S1 and S2 acceptances and detection efficiencies are positive for all events. A common case where the latter would fail is if you forget to apply cuts you told flamedisx about.

Curiously, the trust-constr optimizer throws some ValueError about dimension mismatch for the Hessian in case the guess's likelihood is nonfinite. Not sure what this is about, but I hope we won't see this is again with this check.

I introduced a new `_check_data` function in source, since the check on the S1 acceptance cannot happen directly in annotate (for simulated data, annotate is first called without S1 and S2 values defined ), and so we can also check all required columns are present in the data before producing KeyErrors in populate tensor cache. 