### PR TITLE
Dimension scaling inside optimizers

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -144,7 +144,7 @@ class Objective:
     def normalize(self,
                   x: ty.Union[dict, np.ndarray],
                   input_kind='parameters',
-                  _reverse=True):
+                  _reverse=False):
         """Convert parameters or gradients to normalized space,
         for use inside the optimizer.
 
@@ -599,7 +599,6 @@ class IntervalObjective(Objective):
                       **{self.target_parameter: tp_guess},
                       **self.guess}
         self._process_guess()
-
 
     def t_ppf(self, target_param_value):
         """Return critical value given parameter value and critical

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -190,16 +190,11 @@ class Objective:
     def nan_result(self):
         """Return ObjectiveResult with all values NaN"""
         n = len(self.arg_names)
-        if self.use_hessian:
-            return ObjectiveResult(
-                fun=self.nan_val,
-                grad=np.ones(n) * float('nan'),
-                hess=np.ones((n, n)) * float('nan'))
-        else:
-            return ObjectiveResult(
-                fun=self.nan_val,
-                grad=np.ones(n) * float('nan'),
-                hess=None)
+        return ObjectiveResult(
+            fun=self.nan_val,
+            grad=np.ones(n) * float('nan'),
+            hess=(np.ones((n, n)) * float('nan')
+                  if self.use_hessian else None))
 
     def __call__(self, x_norm):
         """Evaluate the objective function defined in _inner_fun_and_grad.

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -68,8 +68,7 @@ def test_bestfit_minuit(xes):
 
     bestfit = lf.bestfit(guess, optimizer='minuit',
                          return_errors=True,
-                         use_hessian=False,
-                         optimizer_kwargs=dict(error=(0.0001, 1000)))
+                         use_hessian=False)
     assert isinstance(bestfit[0], dict)
     assert len(bestfit[0]) == 2
 


### PR DESCRIPTION
This PR addresses part of issue https://github.com/FlamTeam/flamedisx-notebooks/issues/2

This re-implements the normalization of parameters used by the different optimizers. We had implemented this before but removed it in #40 following a discussion in #36 without really understanding the root cause and assuming that the optimizers work well also with unnormalized/physical parameters. Using SciPy's `trust-constr` method (the current default, because it takes bounds and the hessian) we see in the [Tutorial notebook](https://github.com/FlamTeam/flamedisx-notebooks/blob/master/Tutorial.ipynb) that it has a problem when parameters have values which differ by orders of magnitudes (elife and rate_multiplier). See issue https://github.com/FlamTeam/flamedisx-notebooks/issues/2
Using normalized dimensions fixes this problem.

For example, when optimizing the likelihood of the Tutorial notebook in section '2) Inference', it now correctly varies the elife parameter, where this was stuck at the guess before. The below table shows the output of `Likelihood.bestfit` with `get_history=True` for 250 events. History now includes both scaled and unscaled gradients (scroll right in the table) so we can check the gradient values.

|    |   er_rate_multiplier |   elife |       y |   er_rate_multiplier_grad |   elife_grad |   er_rate_multiplier_scaled_grad |   elife_scaled_grad |
|---:|---------------------:|--------:|--------:|--------------------------:|-------------:|---------------------------------:|--------------------:|
|  0 |            0.03      |  410000 | 3474.77 |          -12508.3         | -0.0022088   |                   -375.248       |      -905.61        |
|  1 |            0.0564236 |  440836 | 3212.05 |           -5855.56        | -0.000404039 |                   -175.667       |      -165.656       |
|  2 |            0.100181  |  449330 | 3039.87 |           -2557.07        | -2.20264e-05 |                    -76.712       |        -9.03082     |
|  3 |            0.160433  |  449728 | 2941.41 |            -960.061       | -4.78694e-08 |                    -28.8018      |        -0.0196265   |
|  4 |            0.218464  |  449606 | 2908.26 |            -254.734       | -4.0518e-09  |                     -7.64202     |        -0.00166124  |
|  5 |            0.247048  |  449546 | 2904.33 |             -29.1218      |  9.61336e-10 |                     -0.873655    |         0.000394148 |
|  6 |            0.251277  |  449537 | 2904.27 |              -0.0992851   |  9.73159e-10 |                     -0.00297855  |         0.000398995 |
|  7 |            0.251292  |  449537 | 2904.27 |               0.00332451  | -1.18325e-09 |                      9.97353e-05 |        -0.000485134 |
|  8 |            0.251292  |  449537 | 2904.27 |               0.000722885 | -1.00499e-09 |                      2.16866e-05 |        -0.000412047 |
|  9 |            0.251292  |  449537 | 2904.27 |               0.000411987 | -1.02682e-09 |                      1.23596e-05 |        -0.000420996 |
| 10 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |
| 11 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |
| 12 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |
| 13 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |
| 14 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |
| 15 |            0.251292  |  449537 | 2904.27 |               0.000112534 | -7.83984e-10 |                      3.37601e-06 |        -0.000321434 |