### PR TITLE
Python 3.8 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: xenial
 python:
 - '3.6'
-- '3.7'
+- '3.8'
 install:
 - pip install -r requirements.txt
 script:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,14 @@
+import numpy as np
 import pandas as pd
 import wimprates as wr
 import flamedisx as fd
 
 def test_j2000_conversion():
-    j2000_times = pd.np.linspace(0., 10000., 100)
+    j2000_times = np.linspace(0., 10000., 100)
 
     # convert j2000 -> event_time -> j2000
     test_times = wr.j2000(fd.j2000_to_event_time(j2000_times))
 
-    pd.np.testing.assert_array_almost_equal(j2000_times,
-                                            test_times,
-                                            decimal=6)
+    np.testing.assert_array_almost_equal(j2000_times,
+                                         test_times,
+                                         decimal=6)


### PR DESCRIPTION
With the release of Tensorflow 2.2.0 our build now also runs on Python 3.8. I suggest we test Py36 and Py38 instead of Py36 and Py37.