### PR TITLE
Auto-guess rate multipliers

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -199,7 +199,6 @@ class LogLikelihood:
                 self.param_defaults[rmname] *= (
                         (n_observed - mu_others) / mu_source)
                 adjusted_rate_for[dname] = True
-                print("Adjusted rate parameter guess to ", self.param_defaults[rmname])
 
         self.batch_info = tf.convert_to_tensor(batch_info, dtype=fd.int_type())
 


### PR DESCRIPTION
For sources with free rates, we currently use a rate multiplier guess of 1. In the common case of one free source, we can easily guess much better based on the number of observed events.

This modifies `Likelihood.set_data` to adjust the default rate multiplier for the first free source in every dataset to `(n_observed - mu_other_sources) / mu_source`. This means we shouldn't have to guess the `er_rate_multiplier` anymore in e.g. the tutorial.

I also extended the `Likelihood.mu` function so you can ask e.g. `ll.mu(source='er')` to get the expected number of ER events. (At the moment you still get a tensorflow constant back though, reflecting its internal use.)