### PR TITLE
Optimization improvements

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -253,16 +253,17 @@ class Objective:
             self._history.append(dict(params=params, y=y,
                                       scaled_grad=grad, grad=result[1]))
 
+        x_desc = dict(zip(self.arg_names, x))
         if np.isnan(y):
-            warnings.warn(f"Objective at {x} is Nan!",
+            warnings.warn(f"Objective at {x_desc} is Nan!",
                           OptimizerWarning)
             result = self.nan_result()
         elif np.any(np.isnan(grad)):
-            warnings.warn(f"Objective at {x} has NaN gradient {grad}",
+            warnings.warn(f"Objective at {x_desc} has NaN gradient {grad}",
                           OptimizerWarning)
             result = self.nan_result()
         elif hess is not None and np.any(np.isnan(hess)):
-            warnings.warn(f"Objective at {x} has NaN Hessian {hess}",
+            warnings.warn(f"Objective at {x_desc} has NaN Hessian {hess}",
                           OptimizerWarning)
             result = self.nan_result()
         else:

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -391,7 +391,8 @@ class ScipyObjective(Objective):
 
         return scipy_optimize.minimize(
             fun=self.fun,
-            x0=np.ones(len(self.arg_names)),
+            # This is NOT an array of ones! 0 and -1 can also appear.
+            x0=self._dict_to_array(self.normalize(self.guess)),
             jac=self.grad,
             **kwargs)
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -231,7 +231,7 @@ class Objective:
             if k in self.bounds:
                 b = self.bounds[k]
                 if not ((b[0] is None or b[0] <= v)
-                        and (b[1] is None or v < b[1])):
+                        and (b[1] is None or v <= b[1])):
                     warnings.warn(
                         f"Optimizer requested likelihood at {k} = {v}, "
                         f"which is outside the bounds {b}.",

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -137,7 +137,7 @@ class Objective:
         # We always scale with positive numbers, so we don't have to reverse
         # any bounds.
         self.scale_vector = np.abs(self._dict_to_array(self.guess))
-        self.scale_vector[self.scale_vector == 0] = 1
+        self.scale_vector[self.scale_vector == 0.] = 1.
 
         # Convert bounds to normed space
         self.normed_bounds = self.normalize(self.bounds, 'bounds')
@@ -730,8 +730,8 @@ class NonlinearIntervalObjective(IntervalObjective, ScipyObjective):
             # Objective is linear
             jac=lambda x: tilt_grad,
             hess=lambda x: np.zeros((n, n)),
-            # The minimizer operates in scaled coordinates
-            x0=np.ones(n),
+            # This is NOT an array of ones! 0 and -1 can also appear.
+            x0=self._dict_to_array(self.normalize(self.guess)),
             constraints=constraint,
             **kwargs)
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -106,13 +106,24 @@ class Objective:
                 if k not in self.guess:
                     raise ValueError("Incomplete guess: {k} missing")
 
+        # Process bounds
         if bounds is None:
             bounds = dict()
+        # Remove bounds on fixed parameters
+        for k in fix:
+            if k in bounds:
+                del bounds[k]
+        # Check bounds validity
+        for k in bounds:
+            if k not in self.arg_names:
+                raise ValueError(
+                    f"Bound on {k} was passed, but this is not among "
+                    f"the parameters of the fit ({self.arg_names})")
         for p in self.arg_names:
             if p.endswith('_rate_multiplier'):
                 bounds.setdefault(p, (LOWER_RATE_MULTIPLIER_BOUND, None))
         self.bounds = bounds
-        self.normed_bounds = dict()
+        self.normed_bounds = dict()    # Set in process_guess
 
         if self.require_complete_guess:
             self._process_guess()

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -503,7 +503,8 @@ class MinuitObjective(Objective):
 
     def parse_result(self, result: Minuit):
         if not result.migrad_ok():
-            # Borrowed from https://github.com/scikit-hep/iminuit/blob/2ff3cd79b84bf3b25b83f78523312a7c48e26b73/iminuit/_minimize.py#L107
+            # Borrowed from https://github.com/scikit-hep/iminuit/blob/
+            # 2ff3cd79b84bf3b25b83f78523312a7c48e26b73/iminuit/_minimize.py#L107
             message = "Migrad failed! "
             fmin = result.get_fmin()
             if fmin.has_reached_call_limit:

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -132,6 +132,10 @@ class LogLikelihood:
         self.param_defaults = fd.values_to_constants(param_defaults)
         self.param_names = list(param_defaults.keys())
 
+        self.default_bounds = {
+            p_name: (start, stop)
+            for p_name, (start, stop, n) in common_param_specs.items()}
+
         self.mu_itps = {
             sname: s.mu_function(
                 n_trials=n_trials,
@@ -491,7 +495,7 @@ class LogLikelihood:
             lf=self,
             guess={**self.guess(), **guess},
             fix=fix,
-            bounds=bounds,
+            bounds={**self.default_bounds, **bounds},
             nan_val=nan_val,
             get_lowlevel_result=get_lowlevel_result,
             get_history=get_history,
@@ -633,7 +637,10 @@ class LogLikelihood:
                 lf=self,
                 guess=req['guess'],
                 fix=fix,
-                bounds={parameter: req['bound'], **bounds},
+                bounds={
+                    **self.default_bounds,
+                    parameter: req['bound'],
+                    **bounds},
                 # TODO: nan_val
                 get_lowlevel_result=get_lowlevel_result,
                 get_history=get_history,

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -54,19 +54,34 @@ class LogLikelihood:
             max_sigma=3,
             n_trials=int(1e5),
             log_constraint=None,
+            bounds_specified=True,
             **common_param_specs):
         """
 
         :param sources: Dictionary {datasetname : {sourcename: class,, ...}, ...}
         or just {sourcename: class} in case you have one dataset
         Every source name must be unique.
+
         :param data: Dictionary {datasetname: pd.DataFrame}
         or just pd.DataFrame if you have one dataset or None if you
         set data later.
+
         :param free_rates: names of sources whose rates are floating
-        :param batch_size:
-        :param max_sigma:
-        :param n_trials:
+
+        :param batch_size: Number of events to use for a computation batch.
+            Higher numbers give better performance, especially for GPUs,
+            at the cost of more memory
+
+        :param max_sigma: Maximum sigma to use in bounds estimation.
+            Higher numbers give better accuracy, at the cost of performance.
+
+        :param n_trials: Number of Monte-Carlo trials for mu estimation.
+
+        :param bounds_specified: If True (default), optimizers will be
+            constrained within the specified parameter ranges.
+
+        :param log_constraint: Logarithm of constraint to include in likelihood
+
         :param **common_param_specs:  param_name = (min, max, anchors), ...
         """
         param_defaults = dict()
@@ -132,9 +147,12 @@ class LogLikelihood:
         self.param_defaults = fd.values_to_constants(param_defaults)
         self.param_names = list(param_defaults.keys())
 
-        self.default_bounds = {
-            p_name: (start, stop)
-            for p_name, (start, stop, n) in common_param_specs.items()}
+        if bounds_specified:
+            self.default_bounds = {
+                p_name: (start, stop)
+                for p_name, (start, stop, n) in common_param_specs.items()}
+        else:
+            self.default_bounds = dict()
 
         self.mu_itps = {
             sname: s.mu_function(


### PR DESCRIPTION
  * Fix a bug in the guess of the scipy optimizers. After the scaling in #72, the guess is not necessarily an array of ones; depending on the signs of the defaults, a guess can also be 0 or -1. With this fix, I don't see the optimizer asking for out-of-bounds values anymore in the tutorial fits.
  * Fix a <= vs < bug that prevented the optimizer from evaluating likelihoods exactly at upper bounds; we just slapped it with NaN if it tried.
  * Use the initial parameter specification by the user as default bounds on all variables. E.g.if you specify `elife=(300e3, 500e3, 2)`, elife isn't allowed to go outside [300e3, 500e3] anymore. To turn off this behaviour, you can either pass `bounds_specified=False` to `Likelihood.__init__`, or set the `bounds` dictionary for any particular optimization manually.
  * Give more descriptive warnings when an optimizer gets an invalid value (NaN or infinity in the objective, gradient, or Hessian)