### PR TITLE
Double photoelectron emission modeling

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -18,7 +18,7 @@ export, __all__ = fd.exporter()
 o = tf.newaxis
 
 quanta_types = 'photon', 'electron'
-signal_name = dict(photon='s1', electron='s2', photoelectron='s1')
+signal_name = dict(photon='s1', electron='s2')
 
 # Data methods that take an additional positional argument
 special_data_methods = [
@@ -193,12 +193,13 @@ class LXeSource(fd.Source):
 
     electron_gain_std = 5.
 
+    double_pe_fraction = 0.219
+
+    # TODO: Since #78, this is the gain per photo-electron, not per photon.
+    # We should refactor this, probably when revisiting annotate / introduce
+    # a block model structure
     photon_gain_mean = 1.
     photon_gain_std = 0.5
-    # TODO, Used in detector_response('photoelectron'), avoid duplication or replace?
-    photoelectron_gain_mean = 1.
-    photoelectron_gain_std = 0.5
-    double_pe_fraction = 0.219
 
     ##
     # Simulation
@@ -426,6 +427,11 @@ class LXeSource(fd.Source):
         for different number of detected quanta (photoelectrons and electrons).
         """
         ndet = self.domain(quanta_type + '_detected', data_tensor)
+
+        assert quanta_type != 'photon', "Direct photon response removed in #78"
+        if quanta_type == 'photoelectron':
+            # TODO See note above: the model functions are currently misnamed
+            quanta_type = 'photon'
 
         observed = self._fetch(
             signal_name[quanta_type], data_tensor=data_tensor)

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -614,7 +614,7 @@ class LXeSource(fd.Source):
                 if qn == "photon":
                     # Add photoelectron bounds as well
                     d['photoelectron_detected_' + bound] = (
-                        n + sign * self.max_sigma * scale * (1 + pdpe)
+                        n * (1 + pdpe) + sign * self.max_sigma * scale * (1 + pdpe)
                     ).round().clip(*self._q_det_clip_range('photoelectron')).astype(np.int)
 
                 # For produced quanta, it is trickier, since the number

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -187,18 +187,36 @@ def test_domain_detected(xes: fd.ERSource):
 
 
 def test_detector_response(xes: fd.ERSource):
-    r = xes.detector_response('photon', xes.data_tensor[0], xes.ptensor_from_kwargs()).numpy()
-    assert r.shape == (n_events, xes.dimsizes['photon_detected'])
+    # Works on either photoelectrons or electrons
+    r = xes.detector_response('electron', xes.data_tensor[0], xes.ptensor_from_kwargs()).numpy()
+    assert r.shape == (n_events, xes.dimsizes['electron_detected'])
 
     # r is p(S1 | detected quanta) as a function of detected quanta
     # so the sum over r isn't meaningful (as long as we're frequentists)
 
     # Maximum likelihood est. of detected quanta is correct
     max_is = r.argmax(axis=1)
-    domain = xes.domain('photon_detected').numpy()
+    domain = xes.domain('electron_detected').numpy()
     found_mle = np_lookup_axis1(domain, max_is)
     np.testing.assert_array_less(
-        np.abs(xes.data['photon_detected_mle'] - found_mle),
+        np.abs(xes.data['electron_detected_mle'] - found_mle),
+        0.5)
+
+
+def test_detector_response_pe(xes: fd.ERSource):
+    # Works on either photoelectrons or electrons
+    r = xes.detector_response('photoelectron', xes.data_tensor[0], xes.ptensor_from_kwargs()).numpy()
+    assert r.shape == (n_events, xes.dimsizes['photoelectron_detected'])
+
+    # r is p(S1 | detected quanta) as a function of detected quanta
+    # so the sum over r isn't meaningful (as long as we're frequentists)
+
+    # Maximum likelihood est. of detected quanta is correct
+    max_is = r.argmax(axis=1)
+    domain = xes.domain('photoelectron_detected').numpy()
+    found_mle = np_lookup_axis1(domain, max_is)
+    np.testing.assert_array_less(
+        np.abs(xes.data['photoelectron_detected_mle'] - found_mle),
         0.5)
 
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -187,37 +187,23 @@ def test_domain_detected(xes: fd.ERSource):
 
 
 def test_detector_response(xes: fd.ERSource):
-    # Works on either photoelectrons or electrons
-    r = xes.detector_response('electron', xes.data_tensor[0], xes.ptensor_from_kwargs()).numpy()
-    assert r.shape == (n_events, xes.dimsizes['electron_detected'])
+    for quanta_name in ['electron', 'photoelectron']:
+        # Works on either photoelectrons or electrons
+        r = xes.detector_response(quanta_name,
+                                  xes.data_tensor[0],
+                                  xes.ptensor_from_kwargs()).numpy()
+        assert r.shape == (n_events, xes.dimsizes[quanta_name + '_detected'])
 
-    # r is p(S1 | detected quanta) as a function of detected quanta
-    # so the sum over r isn't meaningful (as long as we're frequentists)
+        # r is p(S1 | detected electrons) as a function of detected electrons
+        # so the sum over r isn't meaningful (as long as we're frequentists)
 
-    # Maximum likelihood est. of detected quanta is correct
-    max_is = r.argmax(axis=1)
-    domain = xes.domain('electron_detected').numpy()
-    found_mle = np_lookup_axis1(domain, max_is)
-    np.testing.assert_array_less(
-        np.abs(xes.data['electron_detected_mle'] - found_mle),
-        0.5)
-
-
-def test_detector_response_pe(xes: fd.ERSource):
-    # Works on either photoelectrons or electrons
-    r = xes.detector_response('photoelectron', xes.data_tensor[0], xes.ptensor_from_kwargs()).numpy()
-    assert r.shape == (n_events, xes.dimsizes['photoelectron_detected'])
-
-    # r is p(S1 | detected quanta) as a function of detected quanta
-    # so the sum over r isn't meaningful (as long as we're frequentists)
-
-    # Maximum likelihood est. of detected quanta is correct
-    max_is = r.argmax(axis=1)
-    domain = xes.domain('photoelectron_detected').numpy()
-    found_mle = np_lookup_axis1(domain, max_is)
-    np.testing.assert_array_less(
-        np.abs(xes.data['photoelectron_detected_mle'] - found_mle),
-        0.5)
+        # Maximum likelihood est. of detected quanta is correct
+        max_is = r.argmax(axis=1)
+        domain = xes.domain(quanta_name + '_detected').numpy()
+        found_mle = np_lookup_axis1(domain, max_is)
+        np.testing.assert_array_less(
+            np.abs(xes.data[quanta_name + '_detected_mle'] - found_mle),
+            0.5)
 
 
 def test_detection_prob(xes: fd.ERSource):


### PR DESCRIPTION
This implements double photoelectron emission (dpe) modeling using a binomial process instead of the previous gaussian approximation making the model more realistic for low energy S1s.
The probability of the number of dpe's is modeled as: `n_pe - n_photons ~ Binom(n_photons, p=p_dpe)` where `n_pe` is the number of photoelectrons detected, `n_photons` is the number of photons detected and `p_dpe` is de dpe fraction.
To implement this an extra tensor of shape `(n_events, n_photoelectron detected, n_photon detected)` is added to the core flamedisx model and an extra inner dimension `photoelectron_detected` is added. Bounds estimation and simulation is added as well.

The changes have been validated using the [models_check notebook](https://github.com/FlamTeam/flamedisx-notebooks/blob/master/models_check.ipynb)

This implements a solution for issue #68 