### PR TITLE
Bugfix issue 75

### DIFF
--- a/flamedisx/x1t_sr1.py
+++ b/flamedisx/x1t_sr1.py
@@ -72,6 +72,11 @@ class SR1Source:
         mean_eff= g1 / (1. + 0.219)
         return mean_eff * s1_relative_ly
 
+    @staticmethod
+    def s2_acceptance(s2):
+        return tf.where((s2 < 100) | (s2 > 6000),
+                        tf.zeros_like(s2, dtype=fd.float_type()),
+                        tf.ones_like(s2, dtype=fd.float_type()))
 
 
 # ER Source for SR1
@@ -105,11 +110,6 @@ class SR1ERSource(SR1Source,fd.ERSource):
         return tf.clip_by_value(q2 * (tf.constant(1.,dtype=fd.float_type()) - tf.exp(-nq / q3_nq)),
                                 tf.constant(1e-4,dtype=fd.float_type()),
                                 float('inf'))
-    @staticmethod
-    def s2_acceptance(s2):
-        return tf.where((s2 < 100) | (s2 > 6000),
-                        tf.zeros_like(s2, dtype=fd.float_type()),
-                        tf.ones_like(s2, dtype=fd.float_type()))
 
 @export
 class SR1NRSource(SR1Source, fd.NRSource):


### PR DESCRIPTION
This fixes #75 where events with zero S2 acceptance are sometimes simulated.
This was due to `s2_acceptance` being redefined only in the SR1 ER source but not in the SR1 NR source causing ER events with S2s down to 100 pe (correctly) being simulated but then wrongly rejected later by the NR model which still used the default 200 pe threshold.
This moves the acceptance function to the `SR1Source` class such that both ER and NR sources use consistent acceptances.

I've checked that the error does not reappear using the code snippet linked in #75, since the original problem was non-deterministic I've also ran the test with 100 different random seeds, none of which now fail.