### PR TITLE
Pax recon eff

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -170,7 +170,6 @@ class LXeSource(fd.Source):
             tf.ones_like(electrons_detected, dtype=fd.float_type()))
 
     def photon_acceptance(self, photons_detected):
-        print('photon_acceptance: er_nr_base')
         return tf.where(
             photons_detected < self.min_s1_photons_detected,
             tf.zeros_like(photons_detected, dtype=fd.float_type()),

--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -170,6 +170,7 @@ class LXeSource(fd.Source):
             tf.ones_like(electrons_detected, dtype=fd.float_type()))
 
     def photon_acceptance(self, photons_detected):
+        print('photon_acceptance: er_nr_base')
         return tf.where(
             photons_detected < self.min_s1_photons_detected,
             tf.zeros_like(photons_detected, dtype=fd.float_type()),

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -7,9 +7,6 @@ import tensorflow_probability as tfp
 import flamedisx as fd
 import json
 
-import matplotlib.pyplot as plt
-import pdb
-
 export, __all__ = fd.exporter()
 
 o = tf.newaxis


### PR DESCRIPTION
Added `cal_rec_efficiency_tf` in x1t_sr1.py which is called in `photon_acceptance`.

Previously, there is only a requirement for the event to have at least 3 photons detected and a flat unity acceptance thereafter. 

In `cal_rec_efficiency_tf`, the PAX reconstruction efficiency is interpolated from a weighted combination of median and lower/upper bounds similar to the logic in BBF, see https://github.com/XENON1T/bbf/blob/master/bbf/gpu_modules/SignalSimCuda.py#L483. This reconstruction efficiency is then applied to the events via `photon_acceptance`.

