### PR TITLE
Fix beta-binomial bug and bimodality

### DIFF
--- a/flamedisx/er_nr_base.py
+++ b/flamedisx/er_nr_base.py
@@ -383,7 +383,6 @@ class LXeSource(fd.Source):
             pel_fluct = self.gimme('p_electron_fluctuation', bonus_arg=_nq_1d,
                                    data_tensor=data_tensor, ptensor=ptensor)
             pel_fluct = fd.lookup_axis1(pel_fluct, _nq_ind)
-            pel_fluct = tf.clip_by_value(pel_fluct, fd.MIN_FLUCTUATION_P, 1.)
             return rate_nq * fd.beta_binom_pmf(
                 nph,
                 n=nq,
@@ -652,9 +651,6 @@ class LXeSource(fd.Source):
 
         if self.do_pel_fluct:
             d['p_el_fluct'] = gimme('p_electron_fluctuation', d['nq'].values)
-            d['p_el_fluct'] = np.clip(d['p_el_fluct'].values,
-                                      fd.MIN_FLUCTUATION_P,
-                                      1.)
             d['p_el_actual'] = 1. - stats.beta.rvs(
                 *fd.beta_params(1. - d['p_el_mean'], d['p_el_fluct']))
         else:
@@ -745,9 +741,7 @@ class ERSource(LXeSource):
     def p_electron_fluctuation(nq):
         # From SR0, BBF model, right?
         # q3 = 1.7 keV ~= 123 quanta
-        return tf.clip_by_value(0.041 * (1. - tf.exp(-nq / 123.)),
-                                fd.MIN_FLUCTUATION_P,
-                                1.)
+        return 0.041 * (1. - tf.exp(-nq / 123.))
 
     @staticmethod
     def penning_quenching_eff(nph):

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -13,12 +13,12 @@ o = tf.newaxis
 FLOAT_TYPE = tf.float32
 INT_TYPE = tf.int32
 
-# Maximum p_electron and
-# Minimum p_electron probability fluctuation
-# Lower than this, numerical instabilities will occur in the
-# beta-binom pmf.
-MAX_MEAN_P = 0.95
-MIN_FLUCTUATION_P = 0.005
+# Extreme mean and standard deviations give numerical errors
+# in the beta-binomial.
+MAX_MEAN_P = 0.95            # issue #36
+MIN_FLUCTUATION_P = 0.005    # issue #36
+MIN_MEAN_P = 0.011           # issue #83. Adjust if changing MIN_FLUCTUATION_P!
+# The MAX_FLUCTUATION_P depends on the mean, see issue #83.
 
 
 def exporter():
@@ -122,17 +122,23 @@ def safe_p(ps):
 
 
 @export
-def beta_params(mean, sigma):
+def beta_params(mean, sigma, force_valid=True):
     """Convert (p_mean, p_sigma) to (alpha, beta) params of beta distribution
+
+    :param force_valid: If true, adjust values to give valid, stable, and
+      unimodal beta distributions. See issues #36 and #83
     """
-    # From Wikipedia:
-    # variance = 1/(4 * (2 * beta + 1)) = 1/(8 * beta + 4)
-    # mean = 1/(1+beta/alpha)
-    # =>
-    # beta = (1/variance - 4) / 8
-    # alpha
-    b = (1. / (8. * sigma ** 2) - 0.5)
-    a = b * mean / (1. - mean)
+    m, v = mean, sigma ** 2
+
+    if force_valid:
+        m = tf.clip_by_value(m, MIN_MEAN_P, MAX_MEAN_P)
+        max_v = tf.maximum(
+            (m-1)**2 * m / (2-m),
+            m**2 * (1-m)/(1+m))
+        v = tf.clip_by_value(v, MIN_FLUCTUATION_P**2, max_v)
+
+    a = m * (m/v - m**2/v - 1.)
+    b = a * (1/m - 1)
     return a, b
 
 
@@ -144,11 +150,6 @@ def beta_binom_pmf(x, n, p_mean, p_sigma):
     if the success probability p is drawn from a beta distribution
     with mean p_mean and standard deviation p_sigma.
     """
-    # Avoid numerical instabilities
-    # TODO: is there a better way?
-    p_mean = tf.clip_by_value(p_mean, 0., MAX_MEAN_P)
-    p_sigma = tf.clip_by_value(p_sigma, MIN_FLUCTUATION_P, 1.)
-
     a, b = beta_params(p_mean, p_sigma)
     res = tf.exp(
         lgamma(n + 1.) + lgamma(x + a) + lgamma(n - x + b)

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -129,6 +129,7 @@ def beta_params(mean, sigma, force_valid=True):
       unimodal beta distributions. See issues #36 and #83
     """
     m, v = mean, sigma ** 2
+    m, v = np_to_tf(m), np_to_tf(v)  # We're called from numpy sometimes
 
     if force_valid:
         m = tf.clip_by_value(m, MIN_MEAN_P, MAX_MEAN_P)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -83,10 +83,14 @@ def test_multisource(xes: fd.ERSource):
         sources=dict(er=xes.__class__, er2=xes.__class__),
         elife=(100e3, 500e3, 5),
         data=xes.data)
+
     # Prevent jitter from mu interpolator simulation to fail test
     itp = lf.mu_itps['er']
     lf2.mu_itps = dict(er=itp, er2=itp)
-    assert lf2.log_likelihood()[0] == l1[0]
+
+    np.testing.assert_allclose(lf2.log_likelihood()[0],
+                               l1[0],
+                               rtol=1e-6)
 
 
 def test_multisource_er_nr(xes: fd.ERSource):


### PR DESCRIPTION
This fixes two issues in flamedisx's beta bimomial:
  1. We incorrectly computed the beta distribution's alpha and beta given a mean and sigma;
  2. We allowed for bimodal beta distributions, for sufficiently high fluctuations.

I will call alpha = a, beta = b, mean = m, variance = sigma**2 = s for simplicity.

## Alpha beta computation bug
We assumed v = 1/(8 b + 4), but this only holds exactly when a = b. The general expression is v = a b / ((a + b)^2 (a + b + 1)). We can still solve (a, b) given (m, s), though it is [slightly hairier](https://www.wolframalpha.com/input/?i=solve+v+%3D%3D+a+b+%2F+%28%28a+%2B+b%29%5E2+%28a+%2B+b+%2B+1%29%29+and+m+%3D%3D+a%2F%28a%2Bb%29+for+a+and+b).

We did not notice this earlier because  
 - Recombination fluctuations are an extremely small effect at low energies, compared to statistical fluctuations. Given that our current formula is pretty accurate most of the time, the discrepancy with any real data we looked at is very small.
 - Since we use the same (m, s) -> (a, b) conversion in the simulator and the direct computation, an effect like this would never be picked up by the (more sensitive) direct vs MC differential rate computation.


## Bimodality
The beta distribution becomes undefined for a < 0 or b < 0. The solution linked above shows this happens outside a radius 1/2 semicircle around (0.5, 0) in the (m, s) plane.

A bigger constraint is that we want the beta distribution for physical probabilities to be unimodal. However, if max(a, b) < 1, the PDF becomes bimodal -- it will have two local maxima, at 0 and 1 (not necessarily equally large). An extreme case of this is the a = b = 0.5 curve shown in [red on Wikipedia's Beta distribution article](https://en.wikipedia.org/wiki/Beta_distribution).

The bimodality happens on the outer edge of the valid semicircle:

![beta_bimodality](https://user-images.githubusercontent.com/4354311/89205482-1a4a5800-d5b8-11ea-9936-b8e7d6801b08.png)

The green curves can also be derived from the m and s expressions; see the code for the result. After this, flamedisx will clip s to lie under the green curve.

## Minimum mean
Since we now have a maximum on s, besides the minimum we already had (see #37), extreme values of m no longer have any legal s we can pick for them. We already capped the maximum m in #37. I now capped the minimum m at 0.011 (1.1%), since for m = 0.01 the lowest allowed s = 0.005 is just in the bimodal region.

For comparison, reported values of the binomial fluctuation s are around 4-6% (see XENON and LUX papers). In XENON's model, s goes to 0 below 2 keV (see analysis paper II), but this was likely done to avoid fluctuations outside [0, 1] for the Gaussian model. (And at 2 keV, statistical fluctuations are so large that binomial overdispersion would seem very difficult to detect.)

The unimodality constraint already excludes the dangerous region near the edge of the range of validity, so I hope we do not need an extra 'numerical safe zone' around it. (If there is be a super  small turn-up deep in the tail in the beta distribution, that should be OK.)