### PR TITLE
Bugfixes

### DIFF
--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -222,6 +222,9 @@ class SpatialRateEnergySpectrum(FixedShapeEnergySpectrum):
         return self.spatial_rate_pdf.lookup(*positions)
 
     def draw_positions(self, n_events):
+        """Return dictionary with x, y, z, r, theta, drift_time
+        drawn from the spatial rate histogram.
+        """
         data = dict()
         positions = self.spatial_rate_hist.get_random(size=n_events)
         for idx, col in enumerate(self.spatial_rate_hist.axis_names):
@@ -230,6 +233,8 @@ class SpatialRateEnergySpectrum(FixedShapeEnergySpectrum):
             data['x'], data['y'] = fd.pol_to_cart(data['r'], data['theta'])
         else:
             data['r'], data['theta'] = fd.cart_to_pol(data['x'], data['y'])
+
+        data['drift_time'] = - data['z'] / self.drift_velocity
         return data
 
 

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -453,7 +453,10 @@ class Source:
             f"n_events must be an int or float, not {type(n_events)}"
 
         # Draw random "deep truth" variables (energy, position)
-        fix_truth = self.validate_fix_truth(fix_truth)
+        # Pass on a copy of the dict or DataFrame
+        fix_truth = self.validate_fix_truth(fix_truth.copy()
+                                            if fix_truth is not None
+                                            else None)
         sim_data = self.random_truth(n_events, fix_truth=fix_truth, **params)
         assert isinstance(sim_data, pd.DataFrame)
 

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -52,7 +52,7 @@ path_reconstruction_bias_mean_s2 = ['ReconstructionS2BiasMeanLowers_SR1_v2.json'
 
 
 def read_maps_tf(path_bag, is_bbf=False):
-    """ Function to read reconstruction bias/combined cut acceptances/dummy maps. 
+    """ Function to read reconstruction bias/combined cut acceptances/dummy maps.
     Note that this implementation fundamentally assumes upper and lower bounds
     have exactly the same domain definition.
 
@@ -118,13 +118,13 @@ class SR1Source:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         # Loading combined cut acceptances
         self.cut_accept_map_s1, self.cut_accept_domain_s1 = \
             read_maps_tf(path_cut_accept_s1, is_bbf=True)
         self.cut_accept_map_s2, self.cut_accept_domain_s2 = \
             read_maps_tf(path_cut_accept_s2, is_bbf=True)
-            
+
         # Loading reconstruction bias map
         self.recon_map_s1_tf, self.domain_def_s1 = \
             read_maps_tf(path_reconstruction_bias_mean_s1, is_bbf=True)
@@ -201,13 +201,10 @@ class SR1Source:
 
     def s1_acceptance(self,
                       s1,
-                      photon_detection_eff,
-                      photon_gain_mean,
-                      mean_eff=DEFAULT_G1 / (1 + DEFAULT_P_DPE),
+                      cs1,
                       # Only used here, DEFAULT_.. would be super verbose
                       cs1_min=3.,
                       cs1_max=70.):
-        cs1 = mean_eff * s1 / (photon_detection_eff * photon_gain_mean)
         acceptance = tf.where((cs1 > cs1_min) & (cs1 < cs1_max),
                               tf.ones_like(s1, dtype=fd.float_type()),
                               tf.zeros_like(s1, dtype=fd.float_type()))
@@ -220,12 +217,9 @@ class SR1Source:
 
     def s2_acceptance(self,
                       s2,
-                      electron_detection_eff,
-                      electron_gain_mean,
+                      cs2,
                       cs2b_min=50.1,
                       cs2b_max=7940.):
-        cs2 = ((DEFAULT_G2/DEFAULT_EXTRACTION_EFFICIENCY) * s2
-               / (electron_detection_eff * electron_gain_mean))
         acceptance = tf.where((cs2 > cs2b_min) & (cs2 < cs2b_max),
                               tf.ones_like(s2, dtype=fd.float_type()),
                               tf.zeros_like(s2, dtype=fd.float_type()))


### PR DESCRIPTION
After merging in the block system (#81) a few minor bugs have appeared. Two of which have already been fixed on master, two more are in this PR. Here is an overview to keep track of the changes:

- Improvement: Use more efficient bounds for produced photons/electrons, already on master following https://github.com/FlamTeam/flamedisx/commit/4d3754c75e5ddeae03944a0698eee43c846d0448 (see also #66)
- Bug: `model_attributes` of `WIMPEnergySpectrum` were missing parent `model_attributed`, already on master in https://github.com/FlamTeam/flamedisx/commit/fc8b0e9baf66c2023b0fc24234f4364877970509
- Bug: `draw_positions` of `SpatialRateEnergySpectrum` did not include `drift_time`. Fixed in this PR
- Bug: cS1 and cS2 were still computed in `s1_acceptance` and `s2_acceptance` functions of `SR1Source`, this is no longer needed (see #81) and caused a `KeyError`. Fixed in this PR.
- Fix for issue #86: Copy the fix_truth dictionary or DataFrame before validating it such that the original is not modified.