### PR TITLE
Add cS1,cS2 computation to SR1Source

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -172,6 +172,17 @@ class SR1Source:
                           d['y'].values,
                           d['z'].values]))
 
+        # Add cS1 and cS2 following XENON conventions.
+        # Skip this if s1/s2 are not known, since we're simulating
+        # TODO: This is a kludge...
+        if 's1' in d.columns:
+            d['cs1'] = d['s1'] / d['s1_relative_ly']
+        if 's2' in d.columns:
+            d['cs2'] = (
+                d['s2']
+                / d['s2_relative_ly']
+                * np.exp(d['drift_time'] / self.defaults['elife']))
+
     @staticmethod
     def electron_detection_eff(drift_time,
                                *,


### PR DESCRIPTION
This fixes #88 
It adds the cS1,cS2 computation to `add_extra_columns` of  `SR1Source`, in the same way as is done in `SR0Source`. As noted in a comment in the original implementation in `SR0Source`: 'this is a kludge'. Would it be better to add cS1 and cS2 as model functions instead?