### PR TITLE
Do not round MLE of photons detected

### DIFF
--- a/flamedisx/lxe_blocks/double_pe.py
+++ b/flamedisx/lxe_blocks/double_pe.py
@@ -52,7 +52,7 @@ class MakeS1Photoelectrons(fd.Block):
         dpe_fraction = self.gimme_numpy('double_pe_fraction')
         for suffix, intify in (('min', np.floor),
                                ('max', np.ceil),
-                               ('mle', np.round)):
+                               ('mle', lambda x: x)):
             d['photons_detected_' + suffix] = \
                 intify(d['photoelectrons_detected_' + suffix].values
                        / (1 + dpe_fraction))


### PR DESCRIPTION
The `photons_detected_mle` variable, i.e. the maximum-likelihood estimate of photons detected, was rounded to an integer. While technically correct, this causes information loss, so that other variables (e.g. `photons_produced_mle`, `e_vis_mle`) will appear coarser. It is also inconsistent with `electrons_detected_mle`, which is not rounded.

I noticed this because the final output the tutorial now looks odd:

![odd](https://user-images.githubusercontent.com/4354311/96257873-6bfd5e80-0fbb-11eb-9be9-b4eabaacbd92.png)

After this fix, it looks fine again:

![better](https://user-images.githubusercontent.com/4354311/96258103-d0b8b900-0fbb-11eb-9472-68ac599d01b7.png)
