### PR TITLE
Add docs on models with extra columns/dimensions

### DIFF
--- a/docs/source/reference/flamedisx.lxe_blocks.rst
+++ b/docs/source/reference/flamedisx.lxe_blocks.rst
@@ -52,7 +52,6 @@ flamedisx.lxe\_blocks.quanta\_splitting module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/reference/flamedisx.rst
+++ b/docs/source/reference/flamedisx.rst
@@ -5,6 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    flamedisx.lxe_blocks
    flamedisx.xenon
@@ -59,7 +60,6 @@ flamedisx.utils module
    :members:
    :undoc-members:
    :show-inheritance:
-
 
 Module contents
 ---------------

--- a/docs/source/reference/flamedisx.xenon.rst
+++ b/docs/source/reference/flamedisx.xenon.rst
@@ -44,7 +44,6 @@ flamedisx.xenon.x1t\_sr1 module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 


### PR DESCRIPTION
This adds documentation about adding extra columns/dimensions to flamedisx models. This hopefully clarifies some puzzling behaviour @plt109 recently encountered.