### PR TITLE
fix import errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ multihist
 wimprates>=0.3.1
 tqdm
 tensorflow>=2.2.0
-tensorflow_probability>=0.8.0
+tensorflow_probability==0.7.0
 iminuit


### PR DESCRIPTION
With current tensorflow 2.4.0, tensorflow-probability has to be 0.7.0 otherwise I get the following error:
```
from tensorflow.python.autograph.core import naming ImportError: cannot import name 'naming
```
Flamedisx imports fine when I do this. Let me know if there's a better way to solve the import issue, though