### PR TITLE
Minor likelihood fixes/enhancements

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -16,7 +16,7 @@ DEFAULT_DSETNAME = 'the_dataset'
 
 @export
 class LogLikelihood:
-    param_defaults: ty.Dict[str, float]
+    param_defaults: ty.Dict[str, tf.Tensor]
 
     dsetnames: ty.List[str]              # Dataset names
     sources: ty.Dict[str, fd.Source]     # Source name -> Source instance
@@ -464,9 +464,10 @@ class LogLikelihood:
                        0.)
         return ll
 
-    def guess(self):
+    def guess(self) -> ty.Dict[str, float]:
         """Return dictionary of parameter guesses"""
-        return self.param_defaults
+        return {k: v.numpy()
+                for k, v in self.param_defaults.items()}
 
     def params_to_dict(self, values):
         """Return parameter {name: value} dictionary"""

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -56,6 +56,7 @@ class LogLikelihood:
             log_constraint=None,
             bounds_specified=True,
             progress=True,
+            defaults=None,
             **common_param_specs):
         """
 
@@ -85,10 +86,15 @@ class LogLikelihood:
 
         :param progress: Show progress bars during initialization
 
+        :param defaults: dictionary of default parameter values to use for
+            all sources.
+
         :param **common_param_specs:  param_name = (min, max, anchors), ...
         """
         param_defaults = dict()
 
+        if defaults is None:
+            defaults = dict()
         if isinstance(data, pd.DataFrame) or data is None:
             # Only one dataset
             data = {DEFAULT_DSETNAME: data}
@@ -130,7 +136,8 @@ class LogLikelihood:
                           # The source will filter out parameters it does not
                           # take
                           fit_params=list(k for k in common_param_specs.keys()),
-                          batch_size=batch_size)
+                          batch_size=batch_size,
+                          **defaults)
             for sname, sclass in self.sources.items()}
 
         for pname in common_param_specs:

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -267,7 +267,7 @@ class LogLikelihood:
     def simulate(self, fix_truth=None, **params):
         """Simulate events from sources.
         """
-        params = self.prepare_params(params)
+        params = self.prepare_params(params, free_all_rates=True)
         # Collect Source event DFs in ds
         ds = []
         for sname, s in self.sources.items():
@@ -339,9 +339,11 @@ class LogLikelihood:
         hess = -2 * result[2] if result[2] is not None else None
         return -2 * ll, -2 * grad, hess
 
-    def prepare_params(self, kwargs):
+    def prepare_params(self, kwargs, free_all_rates=False):
         for k in kwargs:
             if k not in self.param_defaults:
+                if k.endswith('_rate_multiplier') and free_all_rates:
+                    continue
                 raise ValueError(f"Unknown parameter {k}")
         return {**self.param_defaults, **fd.values_to_constants(kwargs)}
 

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -267,6 +267,7 @@ class LogLikelihood:
     def simulate(self, fix_truth=None, **params):
         """Simulate events from sources.
         """
+        params = self.prepare_params(params)
         # Collect Source event DFs in ds
         ds = []
         for sname, s in self.sources.items():

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -222,6 +222,7 @@ def index_lookup_dict(names, column_widths=None):
 
 @export
 def values_to_constants(kwargs):
+    """Return dictionary with python/numpy values replaced by tf.constant"""
     for k, v in kwargs.items():
         if isinstance(v, (float, int)) or is_numpy_number(v):
             kwargs[k] = tf.constant(v, dtype=float_type())


### PR DESCRIPTION
A few small fixes/enhancements to flamedisx.Likelihood:
 * A new `defaults` argument for `Likelihood.__init__`. This allows you to override defaults for all sources. Now you can collect all your custom defaults in one place (e.g. a config file), load them into a dictionary, then pass them to your likelihood.
  * `Likelihood.guess` should output a dict of python values, not tf.constants. This is consistent with the output of e.g. `Likelihood.bestfit` and other functions.
 * If the likelihood had shape parameters, you could not call `.simulate()` without arguments. Now you can; omitted parameters are replaced by their defaults.
 * Conversely, if you passed shape parameters the likelihood did not take, those parameters were just ignored. So you might think   `Likelihood.simulate(elife=0)` runs a zero-elife simulation, but the elife was actually just left to its default value (unless the likelihood has `elife` as a shape parameter). Now you get an error if you try this. 

(We cannot just let `Likelihood.simulate` accept any parameters, like `Source.simulate`, since the former needs to know the efficiency at the new shape parameters. For this, the likelihood does a series of big simulations when it is initialized, a few for each parameter to be varied. We cannot just vary another parameter without doing more simulations. `Source.simulate` instead expects the user to say how many events are simulated, so it _can_ take arbitrary parameters. )