### PR TITLE
SpatialRateEnergySpectrum's draw_positions should accept parameters

### DIFF
--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -221,7 +221,7 @@ class SpatialRateEnergySpectrum(FixedShapeEnergySpectrum):
             positions = [x, y, z]
         return self.spatial_rate_pdf.lookup(*positions)
 
-    def draw_positions(self, n_events):
+    def draw_positions(self, n_events, **params):
         """Return dictionary with x, y, z, r, theta, drift_time
         drawn from the spatial rate histogram.
         """


### PR DESCRIPTION
In flamedisx, `random_truth` and its minions `draw_positions` and `draw_time` get `**kwargs` of (shape) parameters. This is to help sources whose space , time, or energy distribution depend on fittable parameters. The default sources have no such dependencies, so they simply ignore these extra parameters.

`SpatialRateEnergySpectrum`'s `draw_positions` erroneously didn't accept this `**kwargs`, causing #104. This should fix that.