### PR TITLE
Add recon bias

### DIFF
--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -43,7 +43,7 @@ class MakeFinalSignals(fd.Block):
         tf.print('hi from _simulate')
         aa = self.gimme_numpy('reconstruction_bias_'+self.signal_name,
                 bonus_arg=d[self.signal_name])
-        d[self.signal_name] /= aa
+        d[self.signal_name] *= aa
         #### end test
 
         # Call add_extra_columns now, since s1 and s2 are known and derived
@@ -111,7 +111,7 @@ class MakeFinalSignals(fd.Block):
         # add offset to std to avoid NaNs from norm.pdf if std = 0
         result = tfp.distributions.Normal(
             loc=mean, scale=std + 1e-10
-        ).prob(s_observed*aa)
+        ).prob(s_observed/aa)
 
         # Add detection/selection efficiency
         result *= self.gimme(SIGNAL_NAMES[self.quanta_name] + '_acceptance',

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -9,7 +9,7 @@ import flamedisx as fd
 export, __all__ = fd.exporter()
 o = tf.newaxis
 
-
+import pdb as pdb
 SIGNAL_NAMES = dict(photoelectron='s1', electron='s2')
 
 
@@ -37,6 +37,13 @@ class MakeFinalSignals(fd.Block):
                  * self.gimme_numpy(self.quanta_name + '_gain_mean')),
             scale=(d[self.quanta_name + 's_detected']**0.5
                    * self.gimme_numpy(self.quanta_name + '_gain_std')))
+
+
+        #### start test
+        aa = self.gimme_numpy('reconstruction_bias_'+self.signal_name,
+                bonus_arg=d[self.signal_name])
+        d[self.signal_name] *= aa
+        #### end test
 
         # Call add_extra_columns now, since s1 and s2 are known and derived
         # observables from it (cs1, cs2) might be used in the acceptance.
@@ -79,6 +86,29 @@ class MakeFinalSignals(fd.Block):
         result = tfp.distributions.Normal(
             loc=mean, scale=std + 1e-10
         ).prob(s_observed)
+
+        ###
+
+        aa = self.gimme('reconstruction_bias_'+self.signal_name,
+                data_tensor=data_tensor, ptensor=ptensor,
+                bonus_arg=result)
+        bb = result*aa
+        cc = aa[:, o, o]
+        dd = result*cc
+        tf.print('<<<')
+        tf.print(aa.shape)
+        tf.print(bb.shape)
+        tf.print(cc.shape)
+        tf.print(dd.shape)
+        tf.print(self.quanta_name)
+        tf.print(self.signal_name)
+        tf.print('>>>')
+
+        ## why need SIGNAL_NAMES[self.quanta_name]? cannot self.signal_name?
+        ## what's up with [:, o, o]
+        ## recon bias correction before or after s1_acceptance, s2_acceptance?
+
+        ###
 
         # Add detection/selection efficiency
         result *= self.gimme(SIGNAL_NAMES[self.quanta_name] + '_acceptance',

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -55,11 +55,11 @@ class MakeFinalSignals(fd.Block):
     def _annotate(self, d):
         #### start insertion
         tf.print('hi from _annotate. just ones.')
-        aa = np.ones(np.shape(d[self.signal_name]))
-        '''
+        #aa = np.ones(np.shape(d[self.signal_name]))
+        #'''
         aa = self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
-        '''
+        #'''
         #### end insertion
 
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -92,25 +92,26 @@ class MakeFinalSignals(fd.Block):
         mean = quanta_detected * mean_per_q
         std = quanta_detected ** 0.5 * std_per_q
 
-        # add offset to std to avoid NaNs from norm.pdf if std = 0
-        result = tfp.distributions.Normal(
-            loc=mean, scale=std + 1e-10
-        ).prob(s_observed)
-
         ###
-        tf.print('hi from _compute but temporarily off')
-        '''
+        tf.print('hi from _compute. with bias.')
+        
+        #aa = tf.ones_like(s_observed)
+        #'''
         aa = self.gimme('reconstruction_bias_'+self.signal_name,
                         data_tensor=data_tensor, ptensor=ptensor,
-                        bonus_arg=result)
-        result *= aa
-        '''
+                        bonus_arg=s_observed)
+        #'''
 
         ## why need SIGNAL_NAMES[self.quanta_name]? cannot self.signal_name straight?
         ## what's up with [:, o, o]
         ## recon bias correction before or after s1_acceptance, s2_acceptance?
 
         ###
+
+        # add offset to std to avoid NaNs from norm.pdf if std = 0
+        result = tfp.distributions.Normal(
+            loc=mean, scale=std + 1e-10
+        ).prob(s_observed/aa)
 
         # Add detection/selection efficiency
         result *= self.gimme(SIGNAL_NAMES[self.quanta_name] + '_acceptance',

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -9,7 +9,6 @@ import flamedisx as fd
 export, __all__ = fd.exporter()
 o = tf.newaxis
 
-import pdb as pdb
 SIGNAL_NAMES = dict(photoelectron='s1', electron='s2')
 
 
@@ -52,11 +51,17 @@ class MakeFinalSignals(fd.Block):
         d['p_accepted'] *= self.gimme_numpy(self.signal_name + '_acceptance')
 
     def _annotate(self, d):
+        
+        #### start insertion
+        aa = d[self.signal_name]/self.gimme_numpy('reconstruction_bias_'+\
+                self.signal_name, bonus_arg=d[self.signal_name])
+        #### end insertion
+
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')
         s = self.gimme_numpy(self.quanta_name + '_gain_std')
 
         mle = d[self.quanta_name + 's_detected_mle'] = \
-            (d[self.signal_name] / m).clip(0, None)
+            (aa / m).clip(0, None)
         scale = mle**0.5 * s / m
 
         for bound, sign, intify in (('min', -1, np.floor),

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -94,11 +94,13 @@ class MakeFinalSignals(fd.Block):
         ).prob(s_observed)
 
         ###
-        tf.print('hi from _compute')
+        tf.print('hi from _compute but temporarily off')
+        '''
         aa = self.gimme('reconstruction_bias_'+self.signal_name,
                         data_tensor=data_tensor, ptensor=ptensor,
                         bonus_arg=result)
         result *= aa
+        '''
 
         ## why need SIGNAL_NAMES[self.quanta_name]? cannot self.signal_name straight?
         ## what's up with [:, o, o]

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -54,9 +54,9 @@ class MakeFinalSignals(fd.Block):
 
     def _annotate(self, d):
         #### start insertion
-        tf.print('hi from _annotate. actual bias.')
-        #aa = np.ones(np.shape(d[self.signal_name]))
-        #'''
+        tf.print('hi from _annotate. back to ones.')
+        aa = np.ones(np.shape(d[self.signal_name]))
+        '''
         aa = self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
         #'''

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -55,7 +55,7 @@ class MakeFinalSignals(fd.Block):
     def _annotate(self, d):
         #### start insertion
         tf.print('hi from _annotate. just ones.')
-        #aa = np.ones(np.shape(d[self.signal_name]))
+        aa = np.ones(np.shape(d[self.signal_name]))
         '''
         aa = self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -39,6 +39,7 @@ class MakeFinalSignals(fd.Block):
 
 
         #### start test
+        tf.print('hi from _simulate')
         aa = self.gimme_numpy('reconstruction_bias_'+self.signal_name,
                 bonus_arg=d[self.signal_name])
         d[self.signal_name] *= aa
@@ -51,7 +52,7 @@ class MakeFinalSignals(fd.Block):
         d['p_accepted'] *= self.gimme_numpy(self.signal_name + '_acceptance')
 
     def _annotate(self, d):
-        
+        tf.print('hi from _annotate')
         #### start insertion
         aa = d[self.signal_name]/self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
@@ -93,6 +94,7 @@ class MakeFinalSignals(fd.Block):
         ).prob(s_observed)
 
         ###
+        tf.print('hi from _compute')
         aa = self.gimme('reconstruction_bias_'+self.signal_name,
                         data_tensor=data_tensor, ptensor=ptensor,
                         bonus_arg=result)

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -88,23 +88,12 @@ class MakeFinalSignals(fd.Block):
         ).prob(s_observed)
 
         ###
-
         aa = self.gimme('reconstruction_bias_'+self.signal_name,
-                data_tensor=data_tensor, ptensor=ptensor,
-                bonus_arg=result)
-        bb = result*aa
-        cc = aa[:, o, o]
-        dd = result*cc
-        tf.print('<<<')
-        tf.print(aa.shape)
-        tf.print(bb.shape)
-        tf.print(cc.shape)
-        tf.print(dd.shape)
-        tf.print(self.quanta_name)
-        tf.print(self.signal_name)
-        tf.print('>>>')
+                        data_tensor=data_tensor, ptensor=ptensor,
+                        bonus_arg=result)
+        result *= aa
 
-        ## why need SIGNAL_NAMES[self.quanta_name]? cannot self.signal_name?
+        ## why need SIGNAL_NAMES[self.quanta_name]? cannot self.signal_name straight?
         ## what's up with [:, o, o]
         ## recon bias correction before or after s1_acceptance, s2_acceptance?
 

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -43,7 +43,7 @@ class MakeFinalSignals(fd.Block):
         tf.print('hi from _simulate')
         aa = self.gimme_numpy('reconstruction_bias_'+self.signal_name,
                 bonus_arg=d[self.signal_name])
-        d[self.signal_name] *= aa
+        d[self.signal_name] /= aa
         #### end test
 
         # Call add_extra_columns now, since s1 and s2 are known and derived
@@ -111,7 +111,7 @@ class MakeFinalSignals(fd.Block):
         # add offset to std to avoid NaNs from norm.pdf if std = 0
         result = tfp.distributions.Normal(
             loc=mean, scale=std + 1e-10
-        ).prob(s_observed/aa)
+        ).prob(s_observed*aa)
 
         # Add detection/selection efficiency
         result *= self.gimme(SIGNAL_NAMES[self.quanta_name] + '_acceptance',

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -52,10 +52,13 @@ class MakeFinalSignals(fd.Block):
         d['p_accepted'] *= self.gimme_numpy(self.signal_name + '_acceptance')
 
     def _annotate(self, d):
-        tf.print('hi from _annotate')
         #### start insertion
+        tf.print('hi from _annotate but temporarily off')
+        aa = d[self.signal_name]
+        '''
         aa = d[self.signal_name]/self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
+        '''
         #### end insertion
 
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -55,9 +55,11 @@ class MakeFinalSignals(fd.Block):
     def _annotate(self, d):
         #### start insertion
         tf.print('hi from _annotate. just ones.')
-        aa = np.ones(np.shape(d[self.signal_name]))
-        #aa = self.gimme_numpy('reconstruction_bias_'+\
+        #aa = np.ones(np.shape(d[self.signal_name]))
+        '''
+        aa = self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
+        '''
         #### end insertion
 
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -6,7 +6,6 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 import flamedisx as fd
-import pdb as pdb
 export, __all__ = fd.exporter()
 o = tf.newaxis
 
@@ -40,7 +39,7 @@ class MakeFinalSignals(fd.Block):
 
 
         #### start test
-        tf.print('hi from _simulate')
+        # tf.print('hi from _simulate')
         aa = self.gimme_numpy('reconstruction_bias_'+self.signal_name,
                 bonus_arg=d[self.signal_name])
         d[self.signal_name] *= aa
@@ -54,12 +53,9 @@ class MakeFinalSignals(fd.Block):
 
     def _annotate(self, d):
         #### start insertion
-        tf.print('hi from _annotate. back to ones.')
-        aa = np.ones(np.shape(d[self.signal_name]))
-        '''
-        aa = self.gimme_numpy('reconstruction_bias_'+\
-                self.signal_name, bonus_arg=d[self.signal_name])
-        #'''
+        # Actually, don't think I should be modifying this.
+        # _annotate calculates the min, max, mle for quanta detected
+        # pax recon bias mean is in units of photoelectrons.
         #### end insertion
 
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')
@@ -93,8 +89,7 @@ class MakeFinalSignals(fd.Block):
         std = quanta_detected ** 0.5 * std_per_q
 
         ###
-        tf.print('hi from _compute. with bias.')
-        
+        # tf.print('hi from _compute. with bias.')
         #aa = tf.ones_like(s_observed)
         #'''
         aa = self.gimme('reconstruction_bias_'+self.signal_name,

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -78,7 +78,7 @@ class MakeFinalSignals(fd.Block):
         std = quanta_detected ** 0.5 * std_per_q
 
         # true area = reconstructed area/(bias+1)
-        s_true = self.gimme('reconstruction_bias_'+self.signal_name,
+        s_true = s_observed/self.gimme('reconstruction_bias_'+self.signal_name,
                         data_tensor=data_tensor, ptensor=ptensor,
                         bonus_arg=s_observed)
 

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 import flamedisx as fd
+import pdb as pdb
 export, __all__ = fd.exporter()
 o = tf.newaxis
 
@@ -53,19 +54,17 @@ class MakeFinalSignals(fd.Block):
 
     def _annotate(self, d):
         #### start insertion
-        tf.print('hi from _annotate but temporarily off')
-        aa = d[self.signal_name]
-        '''
-        aa = d[self.signal_name]/self.gimme_numpy('reconstruction_bias_'+\
+        tf.print('hi from _annotate. just ones.')
+        aa = np.ones(np.shape(d[self.signal_name]))
+        #aa = self.gimme_numpy('reconstruction_bias_'+\
                 self.signal_name, bonus_arg=d[self.signal_name])
-        '''
         #### end insertion
 
         m = self.gimme_numpy(self.quanta_name + '_gain_mean')
         s = self.gimme_numpy(self.quanta_name + '_gain_std')
 
         mle = d[self.quanta_name + 's_detected_mle'] = \
-            (aa / m).clip(0, None)
+            ((d[self.signal_name]/aa) / m).clip(0, None)
         scale = mle**0.5 * s / m
 
         for bound, sign, intify in (('min', -1, np.floor),

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -54,7 +54,7 @@ class MakeFinalSignals(fd.Block):
 
     def _annotate(self, d):
         #### start insertion
-        tf.print('hi from _annotate. just ones.')
+        tf.print('hi from _annotate. actual bias.')
         #aa = np.ones(np.shape(d[self.signal_name]))
         #'''
         aa = self.gimme_numpy('reconstruction_bias_'+\

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -171,23 +171,19 @@ class SR1Source:
     def reconstruction_bias_s1(self,
                                s1,
                                bias_pivot_pt1=DEFAULT_S1_RECONSTRUCTION_BIAS_PIVOT):
-        tf.print('!! reconstruction_bias_s1 ')
         reconstruction_bias = cal_bias_tf(s1,
                                           self.recon_map_s1_tf,
                                           self.domain_def_s1,
                                           pivot_pt=bias_pivot_pt1)
-        tf.print('reconstruction_bias_s1 !!')
         return reconstruction_bias
 
     def reconstruction_bias_s2(self,
                                s2,
                                bias_pivot_pt2=DEFAULT_S2_RECONSTRUCTION_BIAS_PIVOT):
-        tf.print('!! reconstruction_bias_s2')
         reconstruction_bias = cal_bias_tf(s2,
                                           self.recon_map_s2_tf,
                                           self.domain_def_s2,
                                           pivot_pt=bias_pivot_pt2)
-        tf.print('reconstruction_bias_s2 !!')
         return reconstruction_bias
 
     def random_truth(self, n_events, fix_truth=None, **params):
@@ -252,12 +248,10 @@ class SR1Source:
     def photon_acceptance(self,
                           photons_detected,
                           scalar=DEFAULT_S1_RECONSTRUCTION_EFFICIENCY_PIVOT):
-        tf.print('!! photon_acceptance')
         acceptance = cal_rec_efficiency_tf(photons_detected,
                                         self.recon_eff_map_s1,
                                         self.domain_def_ph,
                                         scalar)
-        tf.print('photon_acceptance !!')
         return acceptance
 
     def s1_acceptance(self,
@@ -266,7 +260,6 @@ class SR1Source:
                       # Only used here, DEFAULT_.. would be super verbose
                       cs1_min=3.,
                       cs1_max=70.):
-        tf.print('!! s1_acceptance')
         acceptance = tf.where((cs1 > cs1_min) & (cs1 < cs1_max),
                               tf.ones_like(s1, dtype=fd.float_type()),
                               tf.zeros_like(s1, dtype=fd.float_type()))
@@ -275,7 +268,6 @@ class SR1Source:
         acceptance *= interpolate_tf(s1, 
                                      self.cut_accept_map_s1[0],
                                      self.cut_accept_domain_s1)
-        tf.print(' s1_acceptance !!')
         return acceptance
 
     def s2_acceptance(self,
@@ -283,7 +275,6 @@ class SR1Source:
                       cs2,
                       cs2b_min=50.1,
                       cs2b_max=7940.):
-        tf.print('!! s2_acceptance')
         cs2b = cs2*(1-DEFAULT_AREA_FRACTION_TOP)
         acceptance = tf.where((cs2b > cs2b_min) & (cs2b < cs2b_max),
                               tf.ones_like(s2, dtype=fd.float_type()),
@@ -293,7 +284,6 @@ class SR1Source:
         acceptance *= interpolate_tf(s2, 
                                      self.cut_accept_map_s2[0],
                                      self.cut_accept_domain_s2)
-        tf.print('s2_acceptance !!')
         return acceptance
 
 

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -171,19 +171,23 @@ class SR1Source:
     def reconstruction_bias_s1(self,
                                s1,
                                bias_pivot_pt1=DEFAULT_S1_RECONSTRUCTION_BIAS_PIVOT):
+        tf.print('!! reconstruction_bias_s1 ')
         reconstruction_bias = cal_bias_tf(s1,
                                           self.recon_map_s1_tf,
                                           self.domain_def_s1,
                                           pivot_pt=bias_pivot_pt1)
+        tf.print('reconstruction_bias_s1 !!')
         return reconstruction_bias
 
     def reconstruction_bias_s2(self,
                                s2,
                                bias_pivot_pt2=DEFAULT_S2_RECONSTRUCTION_BIAS_PIVOT):
+        tf.print('!! reconstruction_bias_s2')
         reconstruction_bias = cal_bias_tf(s2,
                                           self.recon_map_s2_tf,
                                           self.domain_def_s2,
                                           pivot_pt=bias_pivot_pt2)
+        tf.print('reconstruction_bias_s2 !!')
         return reconstruction_bias
 
     def random_truth(self, n_events, fix_truth=None, **params):
@@ -248,10 +252,12 @@ class SR1Source:
     def photon_acceptance(self,
                           photons_detected,
                           scalar=DEFAULT_S1_RECONSTRUCTION_EFFICIENCY_PIVOT):
+        tf.print('!! photon_acceptance')
         acceptance = cal_rec_efficiency_tf(photons_detected,
                                         self.recon_eff_map_s1,
                                         self.domain_def_ph,
                                         scalar)
+        tf.print('photon_acceptance !!')
         return acceptance
 
     def s1_acceptance(self,
@@ -260,6 +266,7 @@ class SR1Source:
                       # Only used here, DEFAULT_.. would be super verbose
                       cs1_min=3.,
                       cs1_max=70.):
+        tf.print('!! s1_acceptance')
         acceptance = tf.where((cs1 > cs1_min) & (cs1 < cs1_max),
                               tf.ones_like(s1, dtype=fd.float_type()),
                               tf.zeros_like(s1, dtype=fd.float_type()))
@@ -268,6 +275,7 @@ class SR1Source:
         acceptance *= interpolate_tf(s1, 
                                      self.cut_accept_map_s1[0],
                                      self.cut_accept_domain_s1)
+        tf.print(' s1_acceptance !!')
         return acceptance
 
     def s2_acceptance(self,
@@ -275,6 +283,7 @@ class SR1Source:
                       cs2,
                       cs2b_min=50.1,
                       cs2b_max=7940.):
+        tf.print('!! s2_acceptance')
         cs2b = cs2*(1-DEFAULT_AREA_FRACTION_TOP)
         acceptance = tf.where((cs2b > cs2b_min) & (cs2b < cs2b_max),
                               tf.ones_like(s2, dtype=fd.float_type()),
@@ -284,6 +293,7 @@ class SR1Source:
         acceptance *= interpolate_tf(s2, 
                                      self.cut_accept_map_s2[0],
                                      self.cut_accept_domain_s2)
+        tf.print('s2_acceptance !!')
         return acceptance
 
 


### PR DESCRIPTION
The PAX reconstruction bias is defined as bias = (reconstructed_area - true_area)/true_area. This is implemented in this PR in `_simulate` and `_compute` of `MakeFinalSignals`. 

In `_simulate`, the reconstructed area is obtained by multiplying the bias to the true area that is drawn from the Normal distribution with the appropriate mean and standard deviations.

In `_compute`, the PDF of the events are evaluated at the true area instead of the reconstructed area.

`_annotate` is left untouched because it calculates bounds of the detected quanta(photoelectrons, electrons) which is not affected by the reconstruction bias.