### PR TITLE
Fix 'sticky' defaults

### DIFF
--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from contextlib import contextmanager
 import inspect
 
@@ -255,7 +256,7 @@ class Source:
         data tensor state"""
         if data is None:
             raise ValueError("No point in setting data = None temporarily")
-        old_defaults = self.defaults
+        old_defaults = deepcopy(self.defaults)
         if data is None:
             self.set_defaults(**kwargs)
         else:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 from contextlib import contextmanager
 import inspect
 
@@ -256,7 +256,7 @@ class Source:
         data tensor state"""
         if data is None:
             raise ValueError("No point in setting data = None temporarily")
-        old_defaults = deepcopy(self.defaults)
+        old_defaults = copy(self.defaults)
         if data is None:
             self.set_defaults(**kwargs)
         else:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -304,6 +304,11 @@ def test_set_data(xes: fd.ERSource):
         np.testing.assert_array_equal(xes.data['s1'], data2['s1'])
     np.testing.assert_array_equal(xes.data['s1'], data1['s1'])
 
+    # Setting defaults temporarily (see PR #110)
+    with xes._set_temporarily(data2, elife=100e3):
+        pass
+    assert xes.defaults['elife'] == fd.ERSource().defaults['elife']
+
     # Setting for real
     xes.set_data(data2)
     assert xes.data is not data1


### PR DESCRIPTION
This fixes a bug in `Source._set_temporarily`. This low-level function is used during simulation and annotation to temporarily set data and parameters to different values. It's supposed to return a source to the previous state afterwards. 

... only it didn't properly reset the parameters. Thus, if you call simulate/annotate with non-default settings, the default settings actually get overwritten!

This can cause serious trouble, e.g. after

```python
import flamedisx as fd

ll = fd.LogLikelihood(
    sources=dict(er=fd.ERSource),
    elife=(1e6, 1e12, 2))
```
the `ll.sources['er'].defaults['elife']` is now actually 1e12 ns. If you now use e.g. `ll.sources['er'].simulate`, you will be in for a surprise... Fortunately, the likelihood does still remember the original defaults, so you're fine if you use `ll.simulate` instead. (In fact `ll.simulate` will reset the source's defaults to the original values.)

This is only one of the possible places this bug could have an impact though. I think we should merge this quickly -- and a new release is overdue anyway.

Thanks to @jordan-palmer for finding a clear case where this bug rears its ugly head.