### PR TITLE
Read data from XENONnT Flamedisx private repo

### DIFF
--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -7,8 +7,6 @@ import os.path
 import flamedisx as fd
 export, __all__ = fd.exporter()
 
-import pdb
-
 
 # Path to the root folder of the BBF repository, if you have already cloned BBF
 # (Do not export it. If you do, reassigning fd.BBF_PATH won't update this one.)

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -12,6 +12,10 @@ export, __all__ = fd.exporter()
 # (Do not export it. If you do, reassigning fd.BBF_PATH won't update this one.)
 BBF_PATH = './bbf'
 
+# Path to the root folder of the XENONnT/Flamedisx repository, if you have
+# already cloned XENONnT/Flamedisx 
+# (Do not export it. If you do, reassigning fd.NTFD_PATH won't update this one.)
+NTFD_PATH = './Flamedisx'
 
 @export
 def pax_file(x):

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -13,9 +13,10 @@ export, __all__ = fd.exporter()
 BBF_PATH = './bbf'
 
 # Path to the root folder of the XENONnT/Flamedisx repository, if you have
-# already cloned XENONnT/Flamedisx 
+# already cloned XENONnT/Flamedisx
 # (Do not export it. If you do, reassigning fd.NTFD_PATH won't update this one.)
 NTFD_PATH = './Flamedisx'
+
 
 @export
 def pax_file(x):
@@ -95,7 +96,7 @@ def refresh_nt(token=None):
     if os.path.exists(NTFD_PATH):
         fd.run_command(f'rm -rf {NTFD_PATH}')
         fd.run_command(f'git clone https://{token}:x-oauth-basic'
-                   f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
+                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
 
 
 @export

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -48,3 +48,34 @@ def get_bbf_file(data_file_name):
     """
     ensure_bbf()
     return fd.get_resource(f'{BBF_PATH}/bbf/data/{data_file_name}')
+
+
+@export
+def ensure_nt(token=None):
+    """Clones XENONnT/Flamedisx (prompting for credentials) if we do not have it"""
+    if not os.path.exists(NTFD_PATH):
+        print("XENONnT private data requested, we must clone Flamedisx folder (~xx MB).")
+        if token is None:
+            print("    - Create a token with full 'repo' permissions at "
+                  "https://github.com/settings/tokens\n"
+                  "    - Save or write it down somewhere \n"
+                  "    - Type it in the prompt above\n\n"
+                  "'Repository not found' means you didn't give the token"
+                  " full 'repo' permissions.\n"
+                  "'Authentication failed' means you mistyped the token.\n")
+            # We could prompt for username/password instead, but then the password
+            # would be printed in plaintext if there is any problem during cloning.
+            token = getpass.getpass('Github OAuth token: ')
+        fd.run_command(f'git clone https://{token}:x-oauth-basic'
+                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
+
+
+@export
+def get_nt_file(data_file_name):
+    """Return information from file in XENONnT/Flamedisx/...
+
+    Do NOT call on import time --
+    that would make flamedisx unusable to non-XENON folks!
+    """
+    ensure_nt()
+    return fd.get_resource(f'{NTFD_PATH}/{data_file_name}')

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -8,6 +8,7 @@ import flamedisx as fd
 export, __all__ = fd.exporter()
 
 
+import pdb as pdb
 # Path to the root folder of the BBF repository, if you have already cloned BBF
 # (Do not export it. If you do, reassigning fd.BBF_PATH won't update this one.)
 BBF_PATH = './bbf'
@@ -15,7 +16,7 @@ BBF_PATH = './bbf'
 # Path to the root folder of the XENONnT/Flamedisx repository, if you have
 # already cloned XENONnT/Flamedisx
 # (Do not export it. If you do, reassigning fd.NTFD_PATH won't update this one.)
-NTFD_PATH = './Flamedisx'
+NTFD_PATH = './flamedisx_maps'
 
 
 @export
@@ -25,23 +26,33 @@ def pax_file(x):
 
 
 @export
-def ensure_bbf(token=None):
-    """Clones bbf (prompting for credentials) if we do not have it"""
-    if not os.path.exists(BBF_PATH):
-        print("XENON1T private data requested, we must clone BBF (~800 MB).")
-        if token is None:
-            print("    - Create a token with full 'repo' permissions at "
-                  "https://github.com/settings/tokens\n"
-                  "    - Save or write it down somewhere \n"
-                  "    - Type it in the prompt above\n\n"
-                  "'Repository not found' means you didn't give the token"
-                  " full 'repo' permissions.\n"
-                  "'Authentication failed' means you mistyped the token.\n")
-            # We could prompt for username/password instead, but then the password
-            # would be printed in plaintext if there is any problem during cloning.
-            token = getpass.getpass('Github OAuth token: ')
+def ensure_token(token=None):
+    """Requests for token if token is not already available."""
+    if token is None:
+        print("    - Create a token with full 'repo' permissions at "
+              "https://github.com/settings/tokens\n"
+              "    - Save or write it down somewhere \n"
+              "    - Type it in the prompt above\n\n"
+              "'Repository not found' means you didn't give the token"
+              " full 'repo' permissions.\n"
+              "'Authentication failed' means you mistyped the token.\n")
+        # We could prompt for username/password instead, but then the password
+        # would be printed in plaintext if there is any problem during cloning.
+        token = getpass.getpass('Github OAuth token: ')
+    return token
+
+
+@export
+def ensure_repo(repo_name, repo_path, token=None):
+    """Clones private repository (prompting for credentials) if we do not have it"""
+    if not os.path.exists(repo_path):
+        print("Private data requested, we must clone repository folder.")
+        print('in ensure_repo')
+        token = ensure_token()
+        print(f'git clone https://{token}:x-oauth-basic'
+                       f'@github.com/{repo_name} {repo_path}')
         fd.run_command(f'git clone https://{token}:x-oauth-basic'
-                       f'@github.com/XENON1T/bbf.git {BBF_PATH}')
+                       f'@github.com/{repo_name} {repo_path}')
 
 
 @export
@@ -51,7 +62,7 @@ def get_bbf_file(data_file_name):
     Do NOT call on import time --
     that would make flamedisx unusable to non-XENON folks!
     """
-    ensure_bbf()
+    ensure_repo('XENON1T/bbf.git', BBF_PATH)
     return fd.get_resource(f'{BBF_PATH}/bbf/data/{data_file_name}')
 
 
@@ -71,33 +82,22 @@ def ensure_nt(token=None):
             # We could prompt for username/password instead, but then the password
             # would be printed in plaintext if there is any problem during cloning.
             token = getpass.getpass('Github OAuth token: ')
+        print('in ensure_nt')
+        print(f'git clone https://{token}:x-oauth-basic'
+                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
         fd.run_command(f'git clone https://{token}:x-oauth-basic'
                        f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
-
-
+                       
+                       
 @export
-def refresh_nt(token=None):
-    """Cloning latest version of XENONnT/Flamedisx (prompting for credentials) if we do not have it"""
-    print("XENONnT private data requested, we are cloning latest Flamedisx folder (~xx MB).")
-    if token is None:
-        print("    - Create a token with full 'repo' permissions at "
-              "https://github.com/settings/tokens\n"
-              "    - Save or write it down somewhere \n"
-              "    - Type it in the prompt above\n\n"
-              "'Repository not found' means you didn't give the token"
-              " full 'repo' permissions.\n"
-              "'Authentication failed' means you mistyped the token.\n")
-        # We could prompt for username/password instead, but then the password
-        # would be printed in plaintext if there is any problem during cloning.
-        token = getpass.getpass('Github OAuth token: ')
+def get_nt_file_old(data_file_name):
+    """Return information from file in XENONnT/Flamedisx/...
 
-    # `git pull` does not work if not in a git repo and not everybody wants to `git init`
-    # Delete old repo and clone again
-    if os.path.exists(NTFD_PATH):
-        fd.run_command(f'rm -rf {NTFD_PATH}')
-        fd.run_command(f'git clone https://{token}:x-oauth-basic'
-                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
-
+    Do NOT call on import time --
+    that would make flamedisx unusable to non-XENON folks!
+    """
+    ensure_nt()
+    return fd.get_resource(f'{NTFD_PATH}/{data_file_name}')
 
 @export
 def get_nt_file(data_file_name):
@@ -106,5 +106,20 @@ def get_nt_file(data_file_name):
     Do NOT call on import time --
     that would make flamedisx unusable to non-XENON folks!
     """
-    ensure_nt()
+    ensure_repo('XENONnT/Flamedisx.git', NTFD_PATH)
     return fd.get_resource(f'{NTFD_PATH}/{data_file_name}')
+
+
+@export
+def refresh_nt(token=None):
+    """Cloning latest version of XENONnT/Flamedisx (prompting for credentials) if we do not have it"""
+    # `git pull` does not work if not in a git repo and not everybody wants to `git init`
+    # Delete old repo and clone again
+    if os.path.exists(NTFD_PATH):
+        fd.run_command(f'rm -rf {NTFD_PATH}')
+    print("XENONnT private data requested, we are cloning latest Flamedisx folder (~xx MB).")
+    print('aiya bbw')
+    token = ensure_token()
+    print(token)
+    fd.run_command(f'git clone https://{token}:x-oauth-basic'
+                   f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -8,7 +8,6 @@ import flamedisx as fd
 export, __all__ = fd.exporter()
 
 
-import pdb as pdb
 # Path to the root folder of the BBF repository, if you have already cloned BBF
 # (Do not export it. If you do, reassigning fd.BBF_PATH won't update this one.)
 BBF_PATH = './bbf'
@@ -47,10 +46,7 @@ def ensure_repo(repo_name, repo_path, token=None):
     """Clones private repository (prompting for credentials) if we do not have it"""
     if not os.path.exists(repo_path):
         print("Private data requested, we must clone repository folder.")
-        print('in ensure_repo')
         token = ensure_token()
-        print(f'git clone https://{token}:x-oauth-basic'
-                       f'@github.com/{repo_name} {repo_path}')
         fd.run_command(f'git clone https://{token}:x-oauth-basic'
                        f'@github.com/{repo_name} {repo_path}')
 
@@ -65,39 +61,6 @@ def get_bbf_file(data_file_name):
     ensure_repo('XENON1T/bbf.git', BBF_PATH)
     return fd.get_resource(f'{BBF_PATH}/bbf/data/{data_file_name}')
 
-
-@export
-def ensure_nt(token=None):
-    """Clones XENONnT/Flamedisx (prompting for credentials) if we do not have it"""
-    if not os.path.exists(NTFD_PATH):
-        print("XENONnT private data requested, we must clone Flamedisx folder (~xx MB).")
-        if token is None:
-            print("    - Create a token with full 'repo' permissions at "
-                  "https://github.com/settings/tokens\n"
-                  "    - Save or write it down somewhere \n"
-                  "    - Type it in the prompt above\n\n"
-                  "'Repository not found' means you didn't give the token"
-                  " full 'repo' permissions.\n"
-                  "'Authentication failed' means you mistyped the token.\n")
-            # We could prompt for username/password instead, but then the password
-            # would be printed in plaintext if there is any problem during cloning.
-            token = getpass.getpass('Github OAuth token: ')
-        print('in ensure_nt')
-        print(f'git clone https://{token}:x-oauth-basic'
-                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
-        fd.run_command(f'git clone https://{token}:x-oauth-basic'
-                       f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
-                       
-                       
-@export
-def get_nt_file_old(data_file_name):
-    """Return information from file in XENONnT/Flamedisx/...
-
-    Do NOT call on import time --
-    that would make flamedisx unusable to non-XENON folks!
-    """
-    ensure_nt()
-    return fd.get_resource(f'{NTFD_PATH}/{data_file_name}')
 
 @export
 def get_nt_file(data_file_name):
@@ -117,9 +80,7 @@ def refresh_nt(token=None):
     # Delete old repo and clone again
     if os.path.exists(NTFD_PATH):
         fd.run_command(f'rm -rf {NTFD_PATH}')
-    print("XENONnT private data requested, we are cloning latest Flamedisx folder (~xx MB).")
-    print('aiya bbw')
+    print("XENONnT private data requested, we are cloning latest Flamedisx folder.")
     token = ensure_token()
-    print(token)
     fd.run_command(f'git clone https://{token}:x-oauth-basic'
                    f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')

--- a/flamedisx/xenon/data.py
+++ b/flamedisx/xenon/data.py
@@ -7,6 +7,8 @@ import os.path
 import flamedisx as fd
 export, __all__ = fd.exporter()
 
+import pdb
+
 
 # Path to the root folder of the BBF repository, if you have already cloned BBF
 # (Do not export it. If you do, reassigning fd.BBF_PATH won't update this one.)
@@ -72,6 +74,30 @@ def ensure_nt(token=None):
             token = getpass.getpass('Github OAuth token: ')
         fd.run_command(f'git clone https://{token}:x-oauth-basic'
                        f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
+
+
+@export
+def refresh_nt(token=None):
+    """Cloning latest version of XENONnT/Flamedisx (prompting for credentials) if we do not have it"""
+    print("XENONnT private data requested, we are cloning latest Flamedisx folder (~xx MB).")
+    if token is None:
+        print("    - Create a token with full 'repo' permissions at "
+              "https://github.com/settings/tokens\n"
+              "    - Save or write it down somewhere \n"
+              "    - Type it in the prompt above\n\n"
+              "'Repository not found' means you didn't give the token"
+              " full 'repo' permissions.\n"
+              "'Authentication failed' means you mistyped the token.\n")
+        # We could prompt for username/password instead, but then the password
+        # would be printed in plaintext if there is any problem during cloning.
+        token = getpass.getpass('Github OAuth token: ')
+
+    # `git pull` does not work if not in a git repo and not everybody wants to `git init`
+    # Delete old repo and clone again
+    if os.path.exists(NTFD_PATH):
+        fd.run_command(f'rm -rf {NTFD_PATH}')
+        fd.run_command(f'git clone https://{token}:x-oauth-basic'
+                   f'@github.com/XENONnT/Flamedisx.git {NTFD_PATH}')
 
 
 @export

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -63,6 +63,9 @@ path_reconstruction_efficiencies_s1 = ['RecEfficiencyLowers_SR1_70phd_v1.json',
 path_cut_accept_s1 = ['S1AcceptanceSR1_v7_Median.json']
 path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
 
+blah_file = '1t_maps/test_map.json'
+blah = fd.get_nt_file(blah_file)
+
 def read_maps_tf(path_bag, is_bbf=False):
     """ Function to read reconstruction bias/combined cut acceptances/dummy maps.
     Note that this implementation fundamentally assumes upper and lower bounds

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -63,9 +63,6 @@ path_reconstruction_efficiencies_s1 = ['RecEfficiencyLowers_SR1_70phd_v1.json',
 path_cut_accept_s1 = ['S1AcceptanceSR1_v7_Median.json']
 path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
 
-blah_file = '1t_maps/test_map.json'
-blah = fd.get_nt_file(blah_file)
-
 def read_maps_tf(path_bag, is_bbf=False):
     """ Function to read reconstruction bias/combined cut acceptances/dummy maps.
     Note that this implementation fundamentally assumes upper and lower bounds


### PR DESCRIPTION
This allows the user to read files stored in the XENONnT/Flamedisx private repository after the necessary authentication token has been set up. 

```
fname_1t = '1t_maps/test_map.json'
map_1t = fd.get_nt_file(fname_1t)

fname_nt = 'nt_maps/test_map.json'
map_nt = fd.get_nt_file(fname_nt)
```

As the repository gets updated, the user might be required to update his/her local version of the repository. This can be achieved with

```
fd.refresh_nt()
```
which deletes the current local XENONnT Flamedisx private repo and clones the latest version. 