### PR TITLE
Elife interpolated from elife map from private repo

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -20,7 +20,6 @@ DEFAULT_AREA_FRACTION_TOP = 0.63  # fraction of light from top array
 DEFAULT_P_DPE = 0.219
 DEFAULT_EXTRACTION_EFFICIENCY = 0.96
 
-DEFAULT_ELECTRON_LIFETIME = 641e3
 DEFAULT_DRIFT_VELOCITY = 1.34 * 1e-4   # cm/ns, from analysis paper II
 
 DEFAULT_DRIFT_FIELD = 81.
@@ -215,9 +214,8 @@ class SR1Source:
                           d['y'].values,
                           d['z'].values]))
 
-        # Not sure what this old comment is about, did Jordan's patch fix this?
-        # Not good. patchy. event_time should be int since event_time in actual
-        # data is int in ns
+        # Not too good. patchy. event_time should be int since event_time in actual
+        # data is int64 in ns. But need this to be float32 to interpolate.
         if 'elife' not in d.columns:
             d['event_time'] = d['event_time'].astype('float32')
             d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -68,7 +68,7 @@ path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
 ##
 # Loading elife maps
 ##
-variable_elife = True
+variable_elife = False
 path_electron_lifetimes = ['1t_maps/electron_lifetimes_sr1.json']
 
 def read_maps_tf(path_bag, is_bbf=False):

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -239,9 +239,7 @@ class SR1Source:
     def electron_detection_eff(drift_time,
                                elife,
                                *,
-                               #elife=DEFAULT_ELECTRON_LIFETIME, # shouldn't i remove this?
                                extraction_eff=DEFAULT_EXTRACTION_EFFICIENCY):
-        #TODO: include function for elife time dependency
         return extraction_eff * tf.exp(-drift_time / elife)
 
     @staticmethod

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -68,7 +68,7 @@ path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
 ##
 # Loading elife maps
 ##
-variable_elife = False
+variable_elife = True
 path_electron_lifetimes = ['1t_maps/electron_lifetimes_sr1.json']
 
 def read_maps_tf(path_bag, is_bbf=False):

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -230,7 +230,6 @@ class SR1Source:
         # Not good. patchy. event_time should be int since event_time in actual
         # data is int in ns
         if 'elife' not in d.columns:
-            print('Variable elife')
             d['event_time'] = d['event_time'].astype('float32')
             d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
                                     self.domain_def_elife)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -324,9 +324,6 @@ class SR1ERSource(SR1Source, fd.ERSource):
         ni, nex = nq * fi, nq * (1. - fi)
         wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-0.24)
 
-        test = gamma_er * tf.exp(-e_kev / omega_er) * r ** (-0.24)
-        tf.print(test)
-
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant
         r_er = 1. - tf.math.log(1. + ni * wiggle_er) / (ni * wiggle_er)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -239,8 +239,7 @@ class SR1Source:
     @staticmethod
     def electron_detection_eff(drift_time,
                                *,
-                               elife=DEFAULT_ELECTRON_LIFETIME, # shouldn't i
-                               remove this?
+                               elife=DEFAULT_ELECTRON_LIFETIME, # shouldn't i remove this?
                                extraction_eff=DEFAULT_EXTRACTION_EFFICIENCY):
         #TODO: include function for elife time dependency
         return extraction_eff * tf.exp(-drift_time / elife)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -233,12 +233,14 @@ class SR1Source:
             print('Variable elife')
             d['event_time'] = d['event_time'].astype('float32')
             d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
+                                    self.domain_def_elife)
 
 
     @staticmethod
     def electron_detection_eff(drift_time,
                                *,
-                               elife=DEFAULT_ELECTRON_LIFETIME, # shouldn't i remove this?
+                               elife=DEFAULT_ELECTRON_LIFETIME, # shouldn't i
+                               remove this?
                                extraction_eff=DEFAULT_EXTRACTION_EFFICIENCY):
         #TODO: include function for elife time dependency
         return extraction_eff * tf.exp(-drift_time / elife)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -230,14 +230,9 @@ class SR1Source:
         # Not good. patchy. event_time should be int since event_time in actual
         # data is int in ns
         if 'elife' not in d.columns:
-            if elife_variable:
-                print('Variable elife')
-                d['event_time'] = d['event_time'].astype('float32')
-                d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
-                                        self.domain_def_elife)
-            else:
-                print('Constant elife')
-                d['elife'] = DEFAULT_ELECTRON_LIFETIME 
+            print('Variable elife')
+            d['event_time'] = d['event_time'].astype('float32')
+            d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
 
 
     @staticmethod


### PR DESCRIPTION
Changes only affect the ER model in xenon/x1t_sr1.py

The electron lifetime is interpolated from the electron lifetime map pulled from the XENONnT/Flamedisx private repository based on the event time of the event and added as a column in `add_extra_columns`. Subsequently, also in `add_extra_columns`, the cs2 value is calculated using this interpolated electron lifetime instead of the default value of 641us which was previously hardcoded in.

The electron lifetime information is then used in model function `electron_detection_eff` as a positional argument. It was previously a keyword argument (nuisance parameter) which had a default value of 641us.

Performance of this new model, along with ks p-value distributions from multiple MC toys, is documented in [Convo note](http://links.app.convo.com/v1/acc-d87cde0a-409c-11e3-adfe-12313d0421bc/apps/6/messages/Y7CezL6ZgDwU7xOzATirnC76NGL1k8#title=Elife%252520bug%25253A%252520now%252520s2%252520fits%252520well%252520but%252520not%252520cs2%25253F) (under flamedisx tag).