### PR TITLE
added npz to list of supported formats by get_resource

### DIFF
--- a/flamedisx/xenon/resource.py
+++ b/flamedisx/xenon/resource.py
@@ -94,7 +94,7 @@ def get_resource(x, fmt=None):
 
     else:
         # File resource
-        if fmt in ['npy', 'npy_pickle']:
+        if fmt in ['npy', 'npy_pickle', 'npz']:
             result = np.load(x, allow_pickle=fmt == 'npy_pickle')
             if isinstance(result, np.lib.npyio.NpzFile):
                 # Slurp the arrays in the file, so the result can be copied,


### PR DESCRIPTION
This PR adds the `.npz` file format to the list of formats supported by `get_resource` by adding it to the end of the list at https://github.com/FlamTeam/flamedisx/blob/14a15921668f8501e16b219f3438ad59837c700e/flamedisx/xenon/resource.py#L97

The field distortion simulation maps are currently stored in the `.npz` format and this PR allows the user to load those maps with `get_resource'.

This new functionality has been tested on a local machine and on Fried Rice.