### PR TITLE
Rj variable stepping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ resource_cache
 # Data
 *.pkl
 *.csv
+
+# Apple
+.DS_Store

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -432,14 +432,6 @@ class BlockModelSource(fd.Source):
         else:
             return super().domain(x, data_tensor=data_tensor)
 
-    def domain_test(self, x, data_tensor=None):
-        if x in self.initial_dimensions:
-            # Domain computation of the inner dimension is passed to the
-            # first block
-            return self.model_blocks[0].domain(data_tensor=data_tensor)[x]
-        else:
-            return super().domain_test(x, data_tensor=data_tensor)
-
     def _domain_dict(self, dimensions, data_tensor):
         if len(dimensions) == 1:
             return {dimensions[0]:

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -125,8 +125,9 @@ class Block:
         raise NotImplementedError
 
     def _calculate_dimsizes_special(self):
-        """Re-calculate dimension size, steps differently for any dimensions;
-        will need to override _calculate_dimsizes_special() within a block"""
+        """Re-calculate dimension size and steps differently for any
+        dimensions; will need to override _calculate_dimsizes_special()
+        within a block"""
         pass
 
 
@@ -296,7 +297,8 @@ class BlockModelSource(fd.Source):
             # Compute the block
             r = b.compute(data_tensor, ptensor, **kwargs)
 
-            # 
+            # Scale the block by stepped dimenions, if not already done in
+            # another block
             for dim in b_dims:
                 if (dim in self.inner_dimensions) and \
                 (dim not in self.no_step_dimensions) and \

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -66,7 +66,7 @@ class Block:
             else:
                 kwargs.update(self.source._domain_dict(
                 self.dimensions, data_tensor))
-                self._domain_dict_bonus(data_tensor)
+                kwargs.update(self._domain_dict_bonus(data_tensor))
         result = self._compute(data_tensor, ptensor, **kwargs)
         assert result.dtype == fd.float_type(), \
             f"{self}._compute returned tensor of wrong dtype!"

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -23,9 +23,6 @@ class Block:
     # tensors will automatically be calculated), label false otherwise (will be
     # added to bonus_dimensions, any additional domain tensors utilising them
     # will need calculating via the block overriding _domain_dict_bonus())
-    special_dimensions: ty.Tuple[str] # Any dimensions where dimsizes
-    # are calculated differently. Calculation of dimsizes will need calculating
-    # via overriding _calculate_dimsizes_special() within a block
 
     depends_on: ty.Tuple[str] = tuple()
 
@@ -128,7 +125,8 @@ class Block:
         raise NotImplementedError
 
     def _calculate_dimsizes_special(self):
-        """Calculate dimension size for any special_dimensions"""
+        """Re-calculate dimension size, steps differently for any dimensions;
+        will need to override _calculate_dimsizes_special() within a block"""
         pass
 
 
@@ -446,7 +444,7 @@ class BlockModelSource(fd.Source):
         pass
 
     def calculate_dimsizes_special(self):
-        """Calculate dimension size for any special_dimensions; override
+        """Custom calulcation of any dimension sizes and steps; override
         _calculate_dimsizes_special within block"""
         for b in self.model_blocks:
             b._calculate_dimsizes_special()

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -265,7 +265,7 @@ class BlockModelSource(fd.Source):
             # 
             for dim in b_dims:
                 if (dim in self.inner_dimensions) and \
-                (dim not in self.penultimate_dimensions) and \
+                (dim not in self.no_step_dimensions) and \
                 (dim not in already_stepped):
                     step_mul = tf.repeat(self.steps[dim], r.shape[1], axis=1)
                     step_mul = tf.repeat(step_mul[:,:,o], r.shape[2], axis=2)

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -17,6 +17,9 @@ class Block:
     For example, P(electrons_detected | electrons_produced).
     """
     dimensions: ty.Tuple[str]
+    bonus_dimensions: ty.Tuple[ty.Tuple[str, bool]] # Any extra dimensions treated differently.
+    # Label true if they represent an internally contracted hidden variable (will
+    # be added to inner_dimenions), label false otherwise.
 
     depends_on: ty.Tuple[str] = tuple()
 
@@ -148,6 +151,7 @@ class BlockModelSource(fd.Source):
         # Collect attributes from the different blocks in this dictionary:
         collected = {k: [] for k in (
             'dimensions',
+            'bonus_dimensions',
             'model_functions',
             'special_model_functions',
             'model_attributes',
@@ -221,7 +225,9 @@ class BlockModelSource(fd.Source):
         self.inner_dimensions = tuple([
             d for d in collected['dimensions']
             if ((d not in self.final_dimensions)
-                and (d not in self.model_blocks[0].dimensions))])
+                and (d not in self.model_blocks[0].dimensions))]
+            + [d for d in collected['bonus_dimensions']
+            if d[1]==True])
         self.initial_dimensions = self.model_blocks[0].dimensions
 
         super().__init__(*args, **kwargs)

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -302,8 +302,9 @@ class BlockModelSource(fd.Source):
                 (dim not in self.no_step_dimensions) and \
                 (dim not in already_stepped):
                     steps = self._fetch(dim+'_steps', data_tensor=data_tensor)
-                    step_mul = tf.repeat(steps[:,o], r.shape[1], axis=1)
-                    step_mul = tf.repeat(step_mul[:,:,o], r.shape[2], axis=2)
+                    step_mul = tf.repeat(steps[:,o], tf.shape(r)[1], axis=1)
+                    step_mul = tf.repeat(step_mul[:,:,o],
+                    tf.shape(r)[2], axis=2)
                     r *= step_mul
                     already_stepped += (dim,)
 
@@ -430,6 +431,14 @@ class BlockModelSource(fd.Source):
             return self.model_blocks[0].domain(data_tensor=data_tensor)[x]
         else:
             return super().domain(x, data_tensor=data_tensor)
+
+    def domain_test(self, x, data_tensor=None):
+        if x in self.initial_dimensions:
+            # Domain computation of the inner dimension is passed to the
+            # first block
+            return self.model_blocks[0].domain(data_tensor=data_tensor)[x]
+        else:
+            return super().domain_test(x, data_tensor=data_tensor)
 
     def _domain_dict(self, dimensions, data_tensor):
         if len(dimensions) == 1:

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -52,6 +52,7 @@ class LogLikelihood:
             free_rates=None,
             batch_size=10,
             max_sigma=3,
+            max_dim_size=70,
             n_trials=int(1e5),
             log_constraint=None,
             bounds_specified=True,
@@ -76,6 +77,9 @@ class LogLikelihood:
 
         :param max_sigma: Maximum sigma to use in bounds estimation.
             Higher numbers give better accuracy, at the cost of performance.
+
+        :param max_dim_size: Maximum bounds size for inner_dimensions,
+            excluding penultimate_dimensions
 
         :param n_trials: Number of Monte-Carlo trials for mu estimation.
 
@@ -133,6 +137,7 @@ class LogLikelihood:
         self.sources = {
             sname: sclass(data=None,
                           max_sigma=max_sigma,
+                          max_dim_size=max_dim_size,
                           # The source will filter out parameters it does not
                           # take
                           fit_params=list(k for k in common_param_specs.keys()),

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -50,7 +50,7 @@ class LogLikelihood:
                 pd.DataFrame,
                 ty.Dict[str, pd.DataFrame]] = None,
             free_rates=None,
-            batch_size=1,
+            batch_size=10,
             max_sigma=3,
             max_dim_size=70,
             n_trials=int(1e5),

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -50,7 +50,7 @@ class LogLikelihood:
                 pd.DataFrame,
                 ty.Dict[str, pd.DataFrame]] = None,
             free_rates=None,
-            batch_size=10,
+            batch_size=1,
             max_sigma=3,
             max_dim_size=70,
             n_trials=int(1e5),

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -52,7 +52,7 @@ class LogLikelihood:
             free_rates=None,
             batch_size=10,
             max_sigma=3,
-            max_dim_size=70,
+            max_dim_size=100,
             n_trials=int(1e5),
             log_constraint=None,
             bounds_specified=True,
@@ -79,7 +79,7 @@ class LogLikelihood:
             Higher numbers give better accuracy, at the cost of performance.
 
         :param max_dim_size: Maximum bounds size for inner_dimensions,
-            excluding penultimate_dimensions
+            excluding no_step_dimensions
 
         :param n_trials: Number of Monte-Carlo trials for mu estimation.
 

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -52,7 +52,7 @@ class LogLikelihood:
             free_rates=None,
             batch_size=10,
             max_sigma=3,
-            max_dim_size=100,
+            max_dim_size=70,
             n_trials=int(1e5),
             log_constraint=None,
             bounds_specified=True,

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -89,10 +89,10 @@ class DetectPhotonsOrElectrons(fd.Block):
             d[self.quanta_name + 's_produced_' + bound] = intify(
                 n_prod_mle + sign * self.source.max_sigma * _std
             ).clip(0, None).astype(np.int)
-        d['electrons_produced_min'] = 1200
-        d['electrons_produced_max'] = 3200
-        d['photons_produced_min'] = 4000
-        d['photons_produced_max'] = 6000
+        d['electrons_produced_min'] = 500
+        d['electrons_produced_max'] = 1500
+        d['photons_produced_min'] = 2100
+        d['photons_produced_max'] = 3100
 
 
 @export

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -98,6 +98,7 @@ class DetectPhotonsOrElectrons(fd.Block):
 @export
 class DetectPhotons(DetectPhotonsOrElectrons):
     dimensions = ('photons_produced', 'photons_detected')
+    bonus_dimensions = ()
 
     special_model_functions = ('photon_acceptance', 'penning_quenching_eff')
     model_functions = ('photon_detection_eff',) + special_model_functions
@@ -128,6 +129,7 @@ class DetectPhotons(DetectPhotonsOrElectrons):
 @export
 class DetectElectrons(DetectPhotonsOrElectrons):
     dimensions = ('electrons_produced', 'electrons_detected')
+    bonus_dimensions = ()
 
     special_model_functions = ('electron_acceptance',)
     model_functions = ('electron_detection_eff',) + special_model_functions

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -98,7 +98,7 @@ class DetectPhotonsOrElectrons(fd.Block):
 @export
 class DetectPhotons(DetectPhotonsOrElectrons):
     dimensions = ('photons_produced', 'photons_detected')
-    bonus_dimensions = ()
+    extra_dimensions = ()
 
     special_model_functions = ('photon_acceptance', 'penning_quenching_eff')
     model_functions = ('photon_detection_eff',) + special_model_functions
@@ -129,7 +129,7 @@ class DetectPhotons(DetectPhotonsOrElectrons):
 @export
 class DetectElectrons(DetectPhotonsOrElectrons):
     dimensions = ('electrons_produced', 'electrons_detected')
-    bonus_dimensions = ()
+    extra_dimensions = ()
 
     special_model_functions = ('electron_acceptance',)
     model_functions = ('electron_detection_eff',) + special_model_functions

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -89,6 +89,10 @@ class DetectPhotonsOrElectrons(fd.Block):
             d[self.quanta_name + 's_produced_' + bound] = intify(
                 n_prod_mle + sign * self.source.max_sigma * _std
             ).clip(0, None).astype(np.int)
+        d['electrons_produced_min'] = 1000
+        d['electrons_produced_max'] = 3500
+        d['photons_produced_min'] = 4000
+        d['photons_produced_max'] = 6000
 
 
 @export
@@ -100,12 +104,13 @@ class DetectPhotons(DetectPhotonsOrElectrons):
 
     photon_detection_eff = 0.1
 
-    @staticmethod
-    def photon_acceptance(photons_detected):
-        return tf.where(
-            photons_detected < 3,
-            tf.zeros_like(photons_detected, dtype=fd.float_type()),
-            tf.ones_like(photons_detected, dtype=fd.float_type()))
+    # @staticmethod
+    # def photon_acceptance(photons_detected):
+    #     return tf.where(
+    #         photons_detected < 3,
+    #         tf.zeros_like(photons_detected, dtype=fd.float_type()),
+    #         tf.ones_like(photons_detected, dtype=fd.float_type()))
+    photon_acceptance = 1.
 
     quanta_name = 'photon'
 

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -89,10 +89,6 @@ class DetectPhotonsOrElectrons(fd.Block):
             d[self.quanta_name + 's_produced_' + bound] = intify(
                 n_prod_mle + sign * self.source.max_sigma * _std
             ).clip(0, None).astype(np.int)
-        d['electrons_produced_min'] = 500
-        d['electrons_produced_max'] = 1500
-        d['photons_produced_min'] = 2100
-        d['photons_produced_max'] = 3100
 
 
 @export

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -101,13 +101,12 @@ class DetectPhotons(DetectPhotonsOrElectrons):
 
     photon_detection_eff = 0.1
 
-    # @staticmethod
-    # def photon_acceptance(photons_detected):
-    #     return tf.where(
-    #         photons_detected < 3,
-    #         tf.zeros_like(photons_detected, dtype=fd.float_type()),
-    #         tf.ones_like(photons_detected, dtype=fd.float_type()))
-    photon_acceptance = 1.
+    @staticmethod
+    def photon_acceptance(photons_detected):
+        return tf.where(
+            photons_detected < 3,
+            tf.zeros_like(photons_detected, dtype=fd.float_type()),
+            tf.ones_like(photons_detected, dtype=fd.float_type()))
 
     quanta_name = 'photon'
 

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -89,8 +89,8 @@ class DetectPhotonsOrElectrons(fd.Block):
             d[self.quanta_name + 's_produced_' + bound] = intify(
                 n_prod_mle + sign * self.source.max_sigma * _std
             ).clip(0, None).astype(np.int)
-        d['electrons_produced_min'] = 1000
-        d['electrons_produced_max'] = 3500
+        d['electrons_produced_min'] = 1200
+        d['electrons_produced_max'] = 3200
         d['photons_produced_min'] = 4000
         d['photons_produced_max'] = 6000
 

--- a/flamedisx/lxe_blocks/double_pe.py
+++ b/flamedisx/lxe_blocks/double_pe.py
@@ -11,7 +11,7 @@ o = tf.newaxis
 @export
 class MakeS1Photoelectrons(fd.Block):
     dimensions = ('photons_detected', 'photoelectrons_detected')
-    bonus_dimensions = ()
+    extra_dimensions = ()
 
     model_functions = ('double_pe_fraction',)
 

--- a/flamedisx/lxe_blocks/double_pe.py
+++ b/flamedisx/lxe_blocks/double_pe.py
@@ -11,6 +11,7 @@ o = tf.newaxis
 @export
 class MakeS1Photoelectrons(fd.Block):
     dimensions = ('photons_detected', 'photoelectrons_detected')
+    bonus_dimensions = ()
 
     model_functions = ('double_pe_fraction',)
 

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -12,6 +12,7 @@ o = tf.newaxis
 @export
 class EnergySpectrum(fd.FirstBlock):
     dimensions = ('energy',)
+    bonus_dimensions = ()
     model_attributes = (
         'energies',
         'fv_radius', 'fv_high', 'fv_low',

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -33,7 +33,7 @@ class EnergySpectrum(fd.FirstBlock):
     t_stop = pd.to_datetime('2020-09-01T08:28:00')
 
     # Just a dummy 0-10 keV spectrum
-    energies = tf.cast(tf.linspace(0., 10., 1000),
+    energies = tf.cast(tf.linspace(100., 100., 1000),
                        dtype=fd.float_type())
 
     def domain(self, data_tensor):

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -34,7 +34,7 @@ class EnergySpectrum(fd.FirstBlock):
     t_stop = pd.to_datetime('2020-09-01T08:28:00')
 
     # Just a dummy 0-10 keV spectrum
-    energies = tf.cast(tf.linspace(100., 100., 1000),
+    energies = tf.cast(tf.linspace(50., 50., 1000),
                        dtype=fd.float_type())
 
     def domain(self, data_tensor):

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -12,7 +12,7 @@ o = tf.newaxis
 @export
 class EnergySpectrum(fd.FirstBlock):
     dimensions = ('energy',)
-    bonus_dimensions = ()
+    extra_dimensions = ()
     model_attributes = (
         'energies',
         'fv_radius', 'fv_high', 'fv_low',

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -34,7 +34,7 @@ class EnergySpectrum(fd.FirstBlock):
     t_stop = pd.to_datetime('2020-09-01T08:28:00')
 
     # Just a dummy 0-10 keV spectrum
-    energies = tf.cast(tf.linspace(150., 200., 1000),
+    energies = tf.cast(tf.linspace(0., 10., 1000),
                        dtype=fd.float_type())
 
     def domain(self, data_tensor):

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -34,7 +34,7 @@ class EnergySpectrum(fd.FirstBlock):
     t_stop = pd.to_datetime('2020-09-01T08:28:00')
 
     # Just a dummy 0-10 keV spectrum
-    energies = tf.cast(tf.linspace(50., 50., 1000),
+    energies = tf.cast(tf.linspace(150., 200., 1000),
                        dtype=fd.float_type())
 
     def domain(self, data_tensor):

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -102,7 +102,7 @@ class MakeS1(MakeFinalSignals):
     signal_name = 's1'
 
     dimensions = ('photoelectrons_detected', 's1')
-    bonus_dimensions = ()
+    extra_dimensions = ()
     special_model_functions = ('reconstruction_bias_s1',)
     model_functions = (
         'photoelectron_gain_mean',
@@ -142,7 +142,7 @@ class MakeS2(MakeFinalSignals):
     signal_name = 's2'
 
     dimensions = ('electrons_detected', 's2')
-    bonus_dimensions = ()
+    extra_dimensions = ()
     special_model_functions = ('reconstruction_bias_s2',)
     model_functions = (
         ('electron_gain_mean',

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -112,12 +112,11 @@ class MakeS1(MakeFinalSignals):
     photoelectron_gain_mean = 1.
     photoelectron_gain_std = 0.5
 
-    # @staticmethod
-    # def s1_acceptance(s1):
-    #     return tf.where((s1 < 2) | (s1 > 70),
-    #                     tf.zeros_like(s1, dtype=fd.float_type()),
-    #                     tf.ones_like(s1, dtype=fd.float_type()))
-    s1_acceptance = 1.
+    @staticmethod
+    def s1_acceptance(s1):
+        return tf.where((s1 < 2) | (s1 > 70),
+                        tf.zeros_like(s1, dtype=fd.float_type()),
+                        tf.ones_like(s1, dtype=fd.float_type()))
 
     @staticmethod
     def reconstruction_bias_s1(sig):
@@ -156,12 +155,11 @@ class MakeS2(MakeFinalSignals):
 
     electron_gain_std = 5.
 
-    # @staticmethod
-    # def s2_acceptance(s2):
-    #     return tf.where((s2 < 200) | (s2 > 6000),
-    #                     tf.zeros_like(s2, dtype=fd.float_type()),
-    #                     tf.ones_like(s2, dtype=fd.float_type()))
-    s2_acceptance = 1.
+    @staticmethod
+    def s2_acceptance(s2):
+        return tf.where((s2 < 200) | (s2 > 6000),
+                        tf.zeros_like(s2, dtype=fd.float_type()),
+                        tf.ones_like(s2, dtype=fd.float_type()))
 
     @staticmethod
     def reconstruction_bias_s2(sig):

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -111,11 +111,12 @@ class MakeS1(MakeFinalSignals):
     photoelectron_gain_mean = 1.
     photoelectron_gain_std = 0.5
 
-    @staticmethod
-    def s1_acceptance(s1):
-        return tf.where((s1 < 2) | (s1 > 70),
-                        tf.zeros_like(s1, dtype=fd.float_type()),
-                        tf.ones_like(s1, dtype=fd.float_type()))
+    # @staticmethod
+    # def s1_acceptance(s1):
+    #     return tf.where((s1 < 2) | (s1 > 70),
+    #                     tf.zeros_like(s1, dtype=fd.float_type()),
+    #                     tf.ones_like(s1, dtype=fd.float_type()))
+    s1_acceptance = 1.
 
     @staticmethod
     def reconstruction_bias_s1(sig):
@@ -153,11 +154,12 @@ class MakeS2(MakeFinalSignals):
 
     electron_gain_std = 5.
 
-    @staticmethod
-    def s2_acceptance(s2):
-        return tf.where((s2 < 200) | (s2 > 6000),
-                        tf.zeros_like(s2, dtype=fd.float_type()),
-                        tf.ones_like(s2, dtype=fd.float_type()))
+    # @staticmethod
+    # def s2_acceptance(s2):
+    #     return tf.where((s2 < 200) | (s2 > 6000),
+    #                     tf.zeros_like(s2, dtype=fd.float_type()),
+    #                     tf.ones_like(s2, dtype=fd.float_type()))
+    s2_acceptance = 1.
 
     @staticmethod
     def reconstruction_bias_s2(sig):

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -102,6 +102,7 @@ class MakeS1(MakeFinalSignals):
     signal_name = 's1'
 
     dimensions = ('photoelectrons_detected', 's1')
+    bonus_dimensions = ()
     special_model_functions = ('reconstruction_bias_s1',)
     model_functions = (
         'photoelectron_gain_mean',
@@ -141,6 +142,7 @@ class MakeS2(MakeFinalSignals):
     signal_name = 's2'
 
     dimensions = ('electrons_detected', 's2')
+    bonus_dimensions = ()
     special_model_functions = ('reconstruction_bias_s2',)
     model_functions = (
         ('electron_gain_mean',

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -40,10 +40,12 @@ class MakeERQuanta(fd.Block):
         result = tf.cast(tf.equal(quanta_produced_noStep,
         quanta_produced_real), dtype=fd.float_type())
 
-        result_pad_left = tf.pad(result, [[0, 0],
-        [15 - result.shape[1] % 15, 0], [0, 0]])
-        result_pad_right = tf.pad(result, [[0, 0],
-        [0, 15 - result.shape[1] % 15], [0, 0]])
+        padding = int(np.floor(quanta_produced_noStep.shape[1] / \
+        (quanta_produced.shape[1]-1))) - \
+        quanta_produced_noStep.shape[1] % (quanta_produced.shape[1]-1)
+
+        result_pad_left = tf.pad(result, [[0, 0], [padding, 0], [0, 0]])
+        result_pad_right = tf.pad(result, [[0, 0], [0, padding], [0, 0]])
 
         steps = self.source._fetch('quanta_produced_steps',
         data_tensor=data_tensor)

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -185,11 +185,11 @@ def calculate_dimsizes_special(self):
     d['quanta_produced_noStep_steps'] = 1
 
     self.source.dimsizes['electrons_produced'] = \
-    int(tf.reduce_max((self.source._fetch('electrons_produced_max') - \
-    self.source._fetch('electrons_produced_min')) / quanta_steps).numpy())
+    int(np.ceil(tf.reduce_max((self.source._fetch('electrons_produced_max') - \
+    self.source._fetch('electrons_produced_min')) / quanta_steps).numpy()) + 1)
     self.source.dimsizes['photons_produced'] = \
-    int(tf.reduce_max((self.source._fetch('photons_produced_max') - \
-    self.source._fetch('photons_produced_min')) / quanta_steps).numpy())
+    int(np.ceil(tf.reduce_max((self.source._fetch('photons_produced_max') - \
+    self.source._fetch('photons_produced_min')) / quanta_steps).numpy()) + 1)
 
     electrons_produced_dimsizes = (d['electrons_produced_max'].to_numpy() \
     - d['electrons_produced_min'].to_numpy()) / quanta_steps.to_numpy()

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -60,10 +60,9 @@ class MakeERQuanta(fd.Block):
                                         / work).astype(np.int)
 
     def _annotate(self, d):
-        for bound in ('min', 'max'):
-            d['quanta_produced_noStep_' + bound] = (
-                    d['electrons_produced_' + bound]
-                    + d['photons_produced_' + bound])
+        d['quanta_produced_noStep_min'] = (
+                d['electrons_produced_min']
+                + d['photons_produced_min'])
         annotate_ces(self, d)
 
     def _domain_dict_bonus(self, d):

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -40,16 +40,17 @@ class MakeERQuanta(fd.Block):
         result = tf.cast(tf.equal(quanta_produced_noStep,
         quanta_produced_real), dtype=fd.float_type())
 
-        # Chunks to sum result in, to get to same dimension as
+        # Chunks to average result in, to get to same dimension as
         # quanta_produced
         chunks = int(result.shape[1] / quanta_produced.shape[1])
 
-        # Perform the summing - will later multiply by the stepping, so divide
+        # Take the average - will later multiply by the stepping, so divide
         # out by it here
         result_temp = tf.reshape(result, [result.shape[0],
         int(result.shape[1] / chunks), chunks, result.shape[2]])
         result = tf.reduce_sum(result_temp, axis=2) \
-        / self.source.steps['quanta_produced'][:,:,o]
+        / (self.source.steps['quanta_produced'][:, : ,o] \
+        * self.source.steps['quanta_produced'][:, : ,o])
 
         return result
 

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -27,8 +27,11 @@ class MakeERQuanta(fd.Block):
                  quanta_produced,
                  # Dependency domain and value
                  energy, rate_vs_energy,
-                 # Extra tensors for internal use
+                 # Extra domains for internal use
                  quanta_produced_noStep, energy_noStep):
+
+        # We will use the tensors without stepping througout, then reduce
+        # to the correct dimensions for the stepped domains via an averaging
 
         # Assume the intial number of quanta is always the same for each energy
         work = self.gimme('work', data_tensor=data_tensor, ptensor=ptensor)
@@ -40,17 +43,25 @@ class MakeERQuanta(fd.Block):
         result = tf.cast(tf.equal(quanta_produced_noStep,
         quanta_produced_real), dtype=fd.float_type())
 
+        # Padding needed to correctly average over the unstepped quanta
+        # domain to the stepped quanta domain: sum slices in equal chunks with
+        # the necessary padding on either side, then average the two
         padding = int(tf.floor(tf.shape(quanta_produced_noStep)[1] / \
         (tf.shape(quanta_produced)[1]-1))) - \
         tf.shape(quanta_produced_noStep)[1] % (tf.shape(quanta_produced)[1]-1)
 
+        # Do the padding
         result_pad_left = tf.pad(result, [[0, 0], [padding, 0], [0, 0]])
         result_pad_right = tf.pad(result, [[0, 0], [0, padding], [0, 0]])
 
+        # Chunks to reshape into, to allow for summation of slices via a
+        # reduce_sum
         chunks = int(tf.shape(result_pad_left)[1] / tf.shape(quanta_produced)[1])
         steps = self.source._fetch('quanta_produced_steps',
         data_tensor=data_tensor)
 
+        # Average slices padding from the left, diving again by the step size
+        # as this will be multiplied by later (once more than it needs to be)
         result_temp_left = tf.reshape(result_pad_left,
         [tf.shape(result_pad_left)[0],
         int(tf.shape(result_pad_left)[1] / chunks), chunks,
@@ -58,6 +69,8 @@ class MakeERQuanta(fd.Block):
         result_left = tf.reduce_sum(result_temp_left, axis=2) \
         / (steps[:, o ,o] * steps[:, o ,o])
 
+        # Average slices padding from the right, diving again by the step size
+        # as this will be multiplied by later (once more than it needs to be)
         result_temp_right = tf.reshape(result_pad_right,
         [tf.shape(result_pad_right)[0],
         int(tf.shape(result_pad_right)[1] / chunks), chunks,
@@ -65,6 +78,7 @@ class MakeERQuanta(fd.Block):
         result_right = tf.reduce_sum(result_temp_right, axis=2) \
         / (steps[:, o ,o] * steps[:, o ,o])
 
+        # Return the average of the two
         return (result_left + result_right) / 2
 
     def _simulate(self, d):
@@ -118,8 +132,11 @@ class MakeNRQuanta(fd.Block):
                  quanta_produced,
                  # Dependency domain and value
                  energy, rate_vs_energy,
-                 # Extra tensors for internal use
+                 # Extra domains for internal use
                  quanta_produced_noStep, energy_noStep):
+
+        # We will use the tensors without stepping througout, then reduce
+        # to the correct dimensions for the stepped domains via an averaging
 
         work = self.gimme('work', data_tensor=data_tensor, ptensor=ptensor)
         mean_q_produced = (
@@ -132,17 +149,25 @@ class MakeNRQuanta(fd.Block):
         result = tfp.distributions.Poisson(mean_q_produced).prob(
         quanta_produced_noStep)
 
+        # Padding needed to correctly average over the unstepped quanta
+        # domain to the stepped quanta domain: sum slices in equal chunks with
+        # the necessary padding on either side, then average the two
         padding = int(tf.floor(tf.shape(quanta_produced_noStep)[1] / \
         (tf.shape(quanta_produced)[1]-1))) - \
         tf.shape(quanta_produced_noStep)[1] % (tf.shape(quanta_produced)[1]-1)
 
+        # Do the padding
         result_pad_left = tf.pad(result, [[0, 0], [padding, 0], [0, 0]])
         result_pad_right = tf.pad(result, [[0, 0], [0, padding], [0, 0]])
 
+        # Chunks to reshape into, to allow for summation of slices via a
+        # reduce_sum
         chunks = int(tf.shape(result_pad_left)[1] / tf.shape(quanta_produced)[1])
         steps = self.source._fetch('quanta_produced_steps',
         data_tensor=data_tensor)
 
+        # Average slices padding from the left, diving again by the step size
+        # as this will be multiplied by later (once more than it needs to be)
         result_temp_left = tf.reshape(result_pad_left,
         [tf.shape(result_pad_left)[0],
         int(tf.shape(result_pad_left)[1] / chunks), chunks,
@@ -150,6 +175,8 @@ class MakeNRQuanta(fd.Block):
         result_left = tf.reduce_sum(result_temp_left, axis=2) \
         / (steps[:, o ,o] * steps[:, o ,o])
 
+        # Average slices padding from the right, diving again by the step size
+        # as this will be multiplied by later (once more than it needs to be)
         result_temp_right = tf.reshape(result_pad_right,
         [tf.shape(result_pad_right)[0],
         int(tf.shape(result_pad_right)[1] / chunks), chunks,
@@ -157,6 +184,7 @@ class MakeNRQuanta(fd.Block):
         result_right = tf.reduce_sum(result_temp_right, axis=2) \
         / (steps[:, o ,o] * steps[:, o ,o])
 
+        # Return the average of the two
         return (result_left + result_right) / 2
 
     def _simulate(self, d):
@@ -196,7 +224,7 @@ def annotate_ces(self, d):
                 + d['photons_produced_' + bound])
 
 def domain_dict_bonus(self, d):
-    # Calculate cross_domains
+    # Calculate cross_domains from quanta_produced_noStep and energy
     mi = self.source._fetch('quanta_produced_noStep_min',data_tensor=d)[:, o]
     quanta_produced_noStep_domain = mi + tf.range(tf.reduce_max(
     self.source._fetch('quanta_produced_noStep_dimsizes', data_tensor=d)))
@@ -214,6 +242,8 @@ def domain_dict_bonus(self, d):
 def calculate_dimsizes_special(self):
     d = self.source.data
 
+    # Want electrons and photons to have the same stepping: choose the minimum
+    # of the two for each event
     quanta_steps = (d['electrons_produced_steps'] <
     d['photons_produced_steps']) * d['electrons_produced_steps']
     + (d['photons_produced_steps'] <
@@ -222,6 +252,8 @@ def calculate_dimsizes_special(self):
     batch_size = self.source.batch_size
     n_batches = self.source.n_batches
 
+    # Need the electrons/photons steps to be the same within a batch for the
+    # averaging procedure in _compute to work correctly
     for i in range(n_batches):
         quanta_steps[i * batch_size : (i + 1) * batch_size + 1] = \
         max(quanta_steps[i * batch_size : (i + 1) * batch_size + 1])
@@ -231,19 +263,27 @@ def calculate_dimsizes_special(self):
     d['quanta_produced_steps'] = quanta_steps
     d['quanta_produced_noStep_steps'] = 1
 
+    # Ensure that we still cover the full electrons_produced bounds, even if
+    # the stepping has changed
     electrons_produced_dimsizes = np.ceil((
     d['electrons_produced_max'].to_numpy() \
     - d['electrons_produced_min'].to_numpy()) / quanta_steps) + 1
     self.source.dimsizes['electrons_produced'] = electrons_produced_dimsizes
 
+    # Ensure that we still cover the full photons_produced bounds, even if
+    # the stepping has changed
     photons_produced_dimsizes = np.ceil((
     d['photons_produced_max'].to_numpy() \
     - d['photons_produced_min'].to_numpy()) / quanta_steps) + 1
     self.source.dimsizes['photons_produced'] =  photons_produced_dimsizes
 
+    # Correct dimsize for quanta_produced, to cover the full range that the sum
+    # of electrons_produced + photons_produced can take
     quanta_produced_dimsizes = electrons_produced_dimsizes \
     + photons_produced_dimsizes - 1
 
+    # Need the quanta_produced dimsizes to be the same within a batch for the
+    # averaging procedure in _compute to work correctly
     for i in range(n_batches):
         quanta_produced_dimsizes[i * batch_size : (i + 1) * batch_size + 1] = \
         max(quanta_produced_dimsizes[i * batch_size :
@@ -251,5 +291,7 @@ def calculate_dimsizes_special(self):
 
     self.source.dimsizes['quanta_produced'] = quanta_produced_dimsizes
 
+    # Correct dimsizes for quanta_produced_noStep, to cover the full range of
+    # quanta_produced with integer steps
     self.source.dimsizes['quanta_produced_noStep'] = quanta_produced_dimsizes \
     + (quanta_steps - 1) * (quanta_produced_dimsizes - 1)

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -40,43 +40,51 @@ class MakeERQuanta(fd.Block):
             dtype=fd.float_type())
 
         # (n_events, |nq|, |ne|) tensor giving p(nq | e)
-        result = tf.cast(tf.equal(quanta_produced_noStep,
-        quanta_produced_real), dtype=fd.float_type())
+        result = tf.cast(
+            tf.equal(quanta_produced_noStep,
+                     quanta_produced_real), dtype=fd.float_type())
 
         # Padding needed to correctly average over the unstepped quanta
         # domain to the stepped quanta domain: sum slices in equal chunks with
         # the necessary padding on either side, then average the two
-        padding = int(tf.floor(tf.shape(quanta_produced_noStep)[1] / \
-        (tf.shape(quanta_produced)[1]-1))) - \
-        tf.shape(quanta_produced_noStep)[1] % (tf.shape(quanta_produced)[1]-1)
+        padding = int(
+            tf.floor(
+                tf.shape(quanta_produced_noStep)[1] /
+                (tf.shape(quanta_produced)[1]-1))
+        ) - tf.shape(quanta_produced_noStep)[1] % \
+            (tf.shape(quanta_produced)[1]-1)
 
         # Do the padding
         result_pad_left = tf.pad(result, [[0, 0], [padding, 0], [0, 0]])
         result_pad_right = tf.pad(result, [[0, 0], [0, padding], [0, 0]])
 
         # Chunks to reshape into, to allow for summation of slices via a
-        # reduce_sum
+        # reduce_sum
         chunks = int(tf.shape(result_pad_left)[1] / tf.shape(quanta_produced)[1])
         steps = self.source._fetch('quanta_produced_steps',
-        data_tensor=data_tensor)
+                                   data_tensor=data_tensor)
 
         # Average slices padding from the left, diving again by the step size
         # as this will be multiplied by later (once more than it needs to be)
-        result_temp_left = tf.reshape(result_pad_left,
-        [tf.shape(result_pad_left)[0],
-        int(tf.shape(result_pad_left)[1] / chunks), chunks,
-        tf.shape(result_pad_left)[2]])
+        result_temp_left = tf.reshape(
+            result_pad_left,
+            [tf.shape(result_pad_left)[0],
+                int(tf.shape(result_pad_left)[1] / chunks),
+                chunks,
+                tf.shape(result_pad_left)[2]])
         result_left = tf.reduce_sum(result_temp_left, axis=2) \
-        / (steps[:, o ,o] * steps[:, o ,o])
+            / (steps[:, o, o] * steps[:, o, o])
 
         # Average slices padding from the right, diving again by the step size
         # as this will be multiplied by later (once more than it needs to be)
-        result_temp_right = tf.reshape(result_pad_right,
-        [tf.shape(result_pad_right)[0],
-        int(tf.shape(result_pad_right)[1] / chunks), chunks,
-        tf.shape(result_pad_right)[2]])
+        result_temp_right = tf.reshape(
+            result_pad_right,
+            [tf.shape(result_pad_right)[0],
+                int(tf.shape(result_pad_right)[1] / chunks),
+                chunks,
+                tf.shape(result_pad_right)[2]])
         result_right = tf.reduce_sum(result_temp_right, axis=2) \
-        / (steps[:, o ,o] * steps[:, o ,o])
+            / (steps[:, o, o] * steps[:, o, o])
 
         # Return the average of the two
         return (result_left + result_right) / 2
@@ -147,42 +155,49 @@ class MakeNRQuanta(fd.Block):
 
         # (n_events, |nq|, |ne|) tensor giving p(nq | e)
         result = tfp.distributions.Poisson(mean_q_produced).prob(
-        quanta_produced_noStep)
+            quanta_produced_noStep)
 
         # Padding needed to correctly average over the unstepped quanta
         # domain to the stepped quanta domain: sum slices in equal chunks with
         # the necessary padding on either side, then average the two
-        padding = int(tf.floor(tf.shape(quanta_produced_noStep)[1] / \
-        (tf.shape(quanta_produced)[1]-1))) - \
-        tf.shape(quanta_produced_noStep)[1] % (tf.shape(quanta_produced)[1]-1)
+        padding = int(
+            tf.floor(
+                tf.shape(quanta_produced_noStep)[1] /
+                (tf.shape(quanta_produced)[1]-1))
+        ) - tf.shape(quanta_produced_noStep)[1] % \
+            (tf.shape(quanta_produced)[1]-1)
 
         # Do the padding
         result_pad_left = tf.pad(result, [[0, 0], [padding, 0], [0, 0]])
         result_pad_right = tf.pad(result, [[0, 0], [0, padding], [0, 0]])
 
         # Chunks to reshape into, to allow for summation of slices via a
-        # reduce_sum
+        # reduce_sum
         chunks = int(tf.shape(result_pad_left)[1] / tf.shape(quanta_produced)[1])
         steps = self.source._fetch('quanta_produced_steps',
-        data_tensor=data_tensor)
+                                   data_tensor=data_tensor)
 
         # Average slices padding from the left, diving again by the step size
         # as this will be multiplied by later (once more than it needs to be)
-        result_temp_left = tf.reshape(result_pad_left,
-        [tf.shape(result_pad_left)[0],
-        int(tf.shape(result_pad_left)[1] / chunks), chunks,
-        tf.shape(result_pad_left)[2]])
+        result_temp_left = tf.reshape(
+            result_pad_left,
+            [tf.shape(result_pad_left)[0],
+                int(tf.shape(result_pad_left)[1] / chunks),
+                chunks,
+                tf.shape(result_pad_left)[2]])
         result_left = tf.reduce_sum(result_temp_left, axis=2) \
-        / (steps[:, o ,o] * steps[:, o ,o])
+            / (steps[:, o, o] * steps[:, o, o])
 
         # Average slices padding from the right, diving again by the step size
         # as this will be multiplied by later (once more than it needs to be)
-        result_temp_right = tf.reshape(result_pad_right,
-        [tf.shape(result_pad_right)[0],
-        int(tf.shape(result_pad_right)[1] / chunks), chunks,
-        tf.shape(result_pad_right)[2]])
+        result_temp_right = tf.reshape(
+            result_pad_right,
+            [tf.shape(result_pad_right)[0],
+                int(tf.shape(result_pad_right)[1] / chunks),
+                chunks,
+                tf.shape(result_pad_right)[2]])
         result_right = tf.reduce_sum(result_temp_right, axis=2) \
-        / (steps[:, o ,o] * steps[:, o ,o])
+            / (steps[:, o, o] * steps[:, o, o])
 
         # Return the average of the two
         return (result_left + result_right) / 2
@@ -223,21 +238,27 @@ def annotate_ces(self, d):
                 d['electrons_produced_' + bound]
                 + d['photons_produced_' + bound])
 
+
 def domain_dict_bonus(self, d):
     # Calculate cross_domains from quanta_produced_noStep and energy
-    mi = self.source._fetch('quanta_produced_noStep_min',data_tensor=d)[:, o]
+    mi = self.source._fetch('quanta_produced_noStep_min', data_tensor=d)[:, o]
     quanta_produced_noStep_domain = mi + tf.range(tf.reduce_max(
-    self.source._fetch('quanta_produced_noStep_dimsizes', data_tensor=d)))
+        self.source._fetch('quanta_produced_noStep_dimsizes', data_tensor=d)))
     energy_domain = self.source.domain('energy', d)
 
-    quanta_produced_noStep = tf.repeat(quanta_produced_noStep_domain[:, :, o],
-    tf.shape(energy_domain)[1], axis=2)
-    energy_noStep = tf.repeat(energy_domain[:, o, :],
-    tf.shape(quanta_produced_noStep_domain)[1], axis=1)
+    quanta_produced_noStep = tf.repeat(
+        quanta_produced_noStep_domain[:, :, o],
+        tf.shape(energy_domain)[1],
+        axis=2)
+    energy_noStep = tf.repeat(
+        energy_domain[:, o, :],
+        tf.shape(quanta_produced_noStep_domain)[1],
+        axis=1)
 
     # Return as domain_dict
     return dict({'quanta_produced_noStep': quanta_produced_noStep,
-    'energy_noStep': energy_noStep})
+                 'energy_noStep': energy_noStep})
+
 
 def calculate_dimsizes_special(self):
     d = self.source.data
@@ -245,9 +266,10 @@ def calculate_dimsizes_special(self):
     # Want electrons and photons to have the same stepping: choose the minimum
     # of the two for each event
     quanta_steps = (d['electrons_produced_steps'] <=
-    d['photons_produced_steps']) * d['electrons_produced_steps']
-    + (d['photons_produced_steps'] <
-    d['electrons_produced_steps']) * d['photons_produced_steps']
+                    d['photons_produced_steps']) * \
+        d['electrons_produced_steps'] \
+        + (d['photons_produced_steps'] <
+           d['electrons_produced_steps']) * d['photons_produced_steps']
 
     batch_size = self.source.batch_size
     n_batches = self.source.n_batches
@@ -255,8 +277,8 @@ def calculate_dimsizes_special(self):
     # Need the electrons/photons steps to be the same within a batch for the
     # averaging procedure in _compute to work correctly
     for i in range(n_batches):
-        quanta_steps[i * batch_size : (i + 1) * batch_size + 1] = \
-        max(quanta_steps[i * batch_size : (i + 1) * batch_size + 1])
+        quanta_steps[i * batch_size: (i + 1) * batch_size + 1] = \
+            max(quanta_steps[i * batch_size: (i + 1) * batch_size + 1])
 
     d['electrons_produced_steps'] = quanta_steps
     d['photons_produced_steps'] = quanta_steps
@@ -265,33 +287,33 @@ def calculate_dimsizes_special(self):
 
     # Ensure that we still cover the full electrons_produced bounds, even if
     # the stepping has changed
-    electrons_produced_dimsizes = np.ceil((
-    d['electrons_produced_max'].to_numpy() \
-    - d['electrons_produced_min'].to_numpy()) / quanta_steps) + 1
+    electrons_produced_dimsizes = np.ceil(
+        (d['electrons_produced_max'].to_numpy()
+            - d['electrons_produced_min'].to_numpy()) / quanta_steps) + 1
     self.source.dimsizes['electrons_produced'] = electrons_produced_dimsizes
 
     # Ensure that we still cover the full photons_produced bounds, even if
     # the stepping has changed
-    photons_produced_dimsizes = np.ceil((
-    d['photons_produced_max'].to_numpy() \
-    - d['photons_produced_min'].to_numpy()) / quanta_steps) + 1
-    self.source.dimsizes['photons_produced'] =  photons_produced_dimsizes
+    photons_produced_dimsizes = np.ceil(
+        (d['photons_produced_max'].to_numpy()
+            - d['photons_produced_min'].to_numpy()) / quanta_steps) + 1
+    self.source.dimsizes['photons_produced'] = photons_produced_dimsizes
 
     # Correct dimsize for quanta_produced, to cover the full range that the sum
     # of electrons_produced + photons_produced can take
     quanta_produced_dimsizes = electrons_produced_dimsizes \
-    + photons_produced_dimsizes - 1
+        + photons_produced_dimsizes - 1
 
     # Need the quanta_produced dimsizes to be the same within a batch for the
     # averaging procedure in _compute to work correctly
     for i in range(n_batches):
-        quanta_produced_dimsizes[i * batch_size : (i + 1) * batch_size + 1] = \
-        max(quanta_produced_dimsizes[i * batch_size :
-        (i + 1) * batch_size + 1])
+        quanta_produced_dimsizes[i * batch_size: (i + 1) * batch_size + 1] = \
+            max(quanta_produced_dimsizes[i * batch_size:
+                (i + 1) * batch_size + 1])
 
     self.source.dimsizes['quanta_produced'] = quanta_produced_dimsizes
 
     # Correct dimsizes for quanta_produced_noStep, to cover the full range of
     # quanta_produced with integer steps
     self.source.dimsizes['quanta_produced_noStep'] = quanta_produced_dimsizes \
-    + (quanta_steps - 1) * (quanta_produced_dimsizes - 1)
+        + (quanta_steps - 1) * (quanta_produced_dimsizes - 1)

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -184,39 +184,19 @@ def calculate_dimsizes_special(self):
     d['quanta_produced_steps'] = quanta_steps
     d['quanta_produced_noStep_steps'] = 1
 
-    self.source.dimsizes['electrons_produced'] = \
-    int(np.ceil(tf.reduce_max((self.source._fetch('electrons_produced_max') - \
-    self.source._fetch('electrons_produced_min')) / quanta_steps).numpy()) + 1)
-    self.source.dimsizes['photons_produced'] = \
-    int(np.ceil(tf.reduce_max((self.source._fetch('photons_produced_max') - \
-    self.source._fetch('photons_produced_min')) / quanta_steps).numpy()) + 1)
-
     electrons_produced_dimsizes = np.ceil((
     d['electrons_produced_max'].to_numpy() \
     - d['electrons_produced_min'].to_numpy()) / quanta_steps.to_numpy()) + 1
-    self.source.add_to_dimsizes('electrons_produced',
-    electrons_produced_dimsizes)
+    self.source.dimsizes['electrons_produced'] = electrons_produced_dimsizes
 
     photons_produced_dimsizes = np.ceil((
     d['photons_produced_max'].to_numpy() \
     - d['photons_produced_min'].to_numpy()) / quanta_steps.to_numpy()) + 1
-    self.source.add_to_dimsizes('photons_produced',
-    photons_produced_dimsizes)
-
-    self.source.dimsizes['quanta_produced'] = \
-    self.source.dimsizes['electrons_produced'] + \
-    self.source.dimsizes['photons_produced'] - 1
+    self.source.dimsizes['photons_produced'] =  photons_produced_dimsizes
 
     quanta_produced_dimsizes = electrons_produced_dimsizes \
     + photons_produced_dimsizes - 1
-    self.source.add_to_dimsizes('quanta_produced',
-    quanta_produced_dimsizes)
+    self.source.dimsizes['quanta_produced'] = quanta_produced_dimsizes
 
-    self.source.dimsizes['quanta_produced_noStep'] = \
-    self.source.dimsizes['quanta_produced'] + \
-    int(tf.reduce_max((d['quanta_produced_steps'] - 1)).numpy()) * \
-    (self.source.dimsizes['quanta_produced'] - 1)
-
-    self.source.add_to_dimsizes('quanta_produced_noStep',
-    quanta_produced_dimsizes + (quanta_steps.to_numpy() - 1) \
-    * (quanta_produced_dimsizes - 1))
+    self.source.dimsizes['quanta_produced_noStep'] = quanta_produced_dimsizes \
+    + (quanta_steps.to_numpy() - 1) * (quanta_produced_dimsizes - 1)

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -26,7 +26,8 @@ class MakeERQuanta(fd.Block):
                  # Domain
                  quanta_produced,
                  # Dependency domain and value
-                 energy, rate_vs_energy):
+                 energy, rate_vs_energy,
+                 quanta_produced_noStep):
 
         # Assume the intial number of quanta is always the same for each energy
         work = self.gimme('work', data_tensor=data_tensor, ptensor=ptensor)
@@ -57,7 +58,7 @@ class MakeERQuanta(fd.Block):
         annotate_ces(self, d)
 
     def _domain_dict_bonus(self, d):
-        domain_dict_bonus(self, d)
+        return domain_dict_bonus(self, d)
 
 
 @export
@@ -131,15 +132,16 @@ def annotate_ces(self, d):
                 + d['photons_produced_' + bound])
 
 def domain_dict_bonus(self, d):
-    # dimsize += (self.source.dimsizes['quanta_produced'] -
-    # (dimsize % self.source.dimsizes['quanta_produced']))
-    #
-    # quanta_produced_noStep_domain = mi + tf.cast(tf.range(dimsize),
-    # dtype=fd.float_type())
-    # energy_domain = self.source.domain('energy', d)
-    #
-    # quanta_produced_noStep = tf.repeat(quanta_produced_noStep_domain[:, :, o],
-    # energy_domain.shape[1], axis=2)
-    # energy = tf.repeat(energy_domain[:, o, :],
-    # quanta_produced_noStep_domain.shape[1], axis=1)
-    test = 0
+    dimsize = self.source.dimsizes['quanta_produced_noStep']
+    dimsize += (self.source.dimsizes['quanta_produced'] -
+    (dimsize % self.source.dimsizes['quanta_produced']))
+
+    mi = self.source._fetch('quanta_produced_noStep_min',data_tensor=d)[:, o]
+    quanta_produced_noStep_domain = mi + tf.cast(tf.range(dimsize),
+    dtype=fd.float_type())
+    energy_domain = self.source.domain('energy', d)
+
+    quanta_produced_noStep = tf.repeat(quanta_produced_noStep_domain[:, :, o],
+    energy_domain.shape[1], axis=2)
+
+    return dict({'quanta_produced_noStep': quanta_produced_noStep})

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -15,6 +15,7 @@ DEFAULT_WORK_PER_QUANTUM = 13.7e-3
 class MakeERQuanta(fd.Block):
 
     dimensions = ('quanta_produced', 'energy')
+    bonus_dimensions = ()
     depends_on = ((('energy',), 'rate_vs_energy'),)
     model_functions = ('work',)
 

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -244,7 +244,7 @@ def calculate_dimsizes_special(self):
 
     # Want electrons and photons to have the same stepping: choose the minimum
     # of the two for each event
-    quanta_steps = (d['electrons_produced_steps'] <
+    quanta_steps = (d['electrons_produced_steps'] <=
     d['photons_produced_steps']) * d['electrons_produced_steps']
     + (d['photons_produced_steps'] <
     d['electrons_produced_steps']) * d['photons_produced_steps']

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -15,7 +15,7 @@ class MakePhotonsElectronsBinomial(fd.Block):
 
     depends_on = ((('quanta_produced',), 'rate_vs_quanta'),)
     dimensions = ('electrons_produced', 'photons_produced')
-    bonus_dimensions = ()
+    extra_dimensions = ()
 
     special_model_functions = ('p_electron',)
     model_functions = special_model_functions

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -37,10 +37,12 @@ class MakePhotonsElectronsBinomial(fd.Block):
         # ... numbers of total quanta produced
         nq = electrons_produced + photons_produced
         # ... indices in nq arrays: make sure stepping is accounted for!
-        _nq_ind = tf.round((nq - self.source._fetch(
-            'quanta_produced_min', data_tensor=data_tensor)[:, o, o]) \
-        / self.source._fetch('quanta_produced_steps',
-        data_tensor=data_tensor)[:, o, o])
+        _nq_ind = tf.round(
+            (nq - self.source._fetch(
+                'quanta_produced_min', data_tensor=data_tensor
+            )[:, o, o]) / self.source._fetch(
+                'quanta_produced_steps', data_tensor=data_tensor
+            )[:, o, o])
         # ... differential rate
         rate_nq = fd.lookup_axis1(rate_vs_quanta, _nq_ind)
         # ... probability of a quantum to become an electron

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -37,8 +37,9 @@ class MakePhotonsElectronsBinomial(fd.Block):
         # ... numbers of total quanta produced
         nq = electrons_produced + photons_produced
         # ... indices in nq arrays
-        _nq_ind = nq - self.source._fetch(
-            'quanta_produced_min', data_tensor=data_tensor)[:, o, o]
+        _nq_ind = tf.round((nq - self.source._fetch(
+            'quanta_produced_min', data_tensor=data_tensor)[:, o, o]) \
+        / self.source.steps['quanta_produced'][:, :, o])
         # ... differential rate
         rate_nq = fd.lookup_axis1(rate_vs_quanta, _nq_ind)
         # ... probability of a quantum to become an electron

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -93,23 +93,6 @@ class MakePhotonsElectronsBinomial(fd.Block):
                 d['photons_produced_' + suffix]
                 + d['electrons_produced_' + suffix])
 
-    def _calculate_dimsizes_special(self):
-        d = self.source.data
-        steps = (d['electrons_produced_steps'] <
-        d['photons_produced_steps']) * d['electrons_produced_steps']
-        + (d['photons_produced_steps'] <
-        d['electrons_produced_steps']) * d['photons_produced_steps']
-
-        d['electrons_produced_steps'] = steps
-        d['photons_produced_steps'] = steps
-
-        self.source.dimsizes['electrons_produced'] = \
-        int(tf.reduce_max((self.source._fetch('electrons_produced_max') - \
-        self.source._fetch('electrons_produced_min')) / steps).numpy())
-        self.source.dimsizes['photons_produced'] = \
-        int(tf.reduce_max((self.source._fetch('photons_produced_max') - \
-        self.source._fetch('photons_produced_min')) / steps).numpy())
-
 
 @export
 class MakePhotonsElectronsBetaBinomial(MakePhotonsElectronsBinomial):

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -15,6 +15,7 @@ class MakePhotonsElectronsBinomial(fd.Block):
 
     depends_on = ((('quanta_produced',), 'rate_vs_quanta'),)
     dimensions = ('electrons_produced', 'photons_produced')
+    bonus_dimensions = ()
 
     special_model_functions = ('p_electron',)
     model_functions = special_model_functions

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -36,7 +36,7 @@ class MakePhotonsElectronsBinomial(fd.Block):
         # containing:
         # ... numbers of total quanta produced
         nq = electrons_produced + photons_produced
-        # ... indices in nq arrays
+        # ... indices in nq arrays: make sure stepping is accounted for!
         _nq_ind = tf.round((nq - self.source._fetch(
             'quanta_produced_min', data_tensor=data_tensor)[:, o, o]) \
         / self.source._fetch('quanta_produced_steps',

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -39,7 +39,8 @@ class MakePhotonsElectronsBinomial(fd.Block):
         # ... indices in nq arrays
         _nq_ind = tf.round((nq - self.source._fetch(
             'quanta_produced_min', data_tensor=data_tensor)[:, o, o]) \
-        / self.source.steps['quanta_produced'][:, :, o])
+        / self.source._fetch('quanta_produced_steps',
+        data_tensor=data_tensor)[:, o, o])
         # ... differential rate
         rate_nq = fd.lookup_axis1(rate_vs_quanta, _nq_ind)
         # ... probability of a quantum to become an electron

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -93,6 +93,23 @@ class MakePhotonsElectronsBinomial(fd.Block):
                 d['photons_produced_' + suffix]
                 + d['electrons_produced_' + suffix])
 
+    def _calculate_dimsizes_special(self):
+        d = self.source.data
+        steps = (d['electrons_produced_steps'] <
+        d['photons_produced_steps']) * d['electrons_produced_steps']
+        + (d['photons_produced_steps'] <
+        d['electrons_produced_steps']) * d['photons_produced_steps']
+
+        d['electrons_produced_steps'] = steps
+        d['photons_produced_steps'] = steps
+
+        self.source.dimsizes['electrons_produced'] = \
+        int(tf.reduce_max((self.source._fetch('electrons_produced_max') - \
+        self.source._fetch('electrons_produced_min')) / steps).numpy())
+        self.source.dimsizes['photons_produced'] = \
+        int(tf.reduce_max((self.source._fetch('photons_produced_max') - \
+        self.source._fetch('photons_produced_min')) / steps).numpy())
+
 
 @export
 class MakePhotonsElectronsBetaBinomial(MakePhotonsElectronsBinomial):

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -49,11 +49,11 @@ class NRSource(fd.BlockModelSource):
         fd.MakeS2)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ('quanta_produced', 'photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
 
     # Use a larger default energy range, since most energy is lost
     # to heat.
-    energies = tf.cast(tf.linspace(0.7, 150., 100),
+    energies = tf.cast(tf.linspace(50., 50., 100),
                        fd.float_type())
     rates_vs_energy = tf.ones(100, fd.float_type())
 

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -34,7 +34,6 @@ class ERSource(fd.BlockModelSource):
 
     final_dimensions = ('s1', 's2')
     no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
-    special_dimensions = ('quanta_produced', 'quanta_produced_noStep')
 
 
 @export

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -34,6 +34,7 @@ class ERSource(fd.BlockModelSource):
 
     final_dimensions = ('s1', 's2')
     no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
+    special_dimensions = ('quanta_produced', 'quanta_produced_noStep')
 
 
 @export

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -53,7 +53,7 @@ class NRSource(fd.BlockModelSource):
 
     # Use a larger default energy range, since most energy is lost
     # to heat.
-    energies = tf.cast(tf.linspace(150., 200., 100),
+    energies = tf.cast(tf.linspace(0.7, 150., 100),
                        fd.float_type())
     rates_vs_energy = tf.ones(100, fd.float_type())
 

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -33,7 +33,7 @@ class ERSource(fd.BlockModelSource):
         return fd.safe_p(qy * 13.7e-3)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ('quanta_produced', 'photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
 
 
 @export

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -33,7 +33,7 @@ class ERSource(fd.BlockModelSource):
         return fd.safe_p(qy * 13.7e-3)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ()
 
 
 @export
@@ -49,11 +49,11 @@ class NRSource(fd.BlockModelSource):
         fd.MakeS2)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ('photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ()
 
     # Use a larger default energy range, since most energy is lost
     # to heat.
-    energies = tf.cast(tf.linspace(50., 50., 100),
+    energies = tf.cast(tf.linspace(150., 200., 100),
                        fd.float_type())
     rates_vs_energy = tf.ones(100, fd.float_type())
 

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -33,6 +33,7 @@ class ERSource(fd.BlockModelSource):
         return fd.safe_p(qy * 13.7e-3)
 
     final_dimensions = ('s1', 's2')
+    penultimate_dimensions = ('photoelectrons_detected', 'electrons_detected')
 
 
 @export
@@ -48,6 +49,7 @@ class NRSource(fd.BlockModelSource):
         fd.MakeS2)
 
     final_dimensions = ('s1', 's2')
+    penultimate_dimensions = ('photoelectrons_detected', 'electrons_detected')
 
     # Use a larger default energy range, since most energy is lost
     # to heat.

--- a/flamedisx/lxe_sources.py
+++ b/flamedisx/lxe_sources.py
@@ -33,7 +33,7 @@ class ERSource(fd.BlockModelSource):
         return fd.safe_p(qy * 13.7e-3)
 
     final_dimensions = ('s1', 's2')
-    penultimate_dimensions = ('photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ('quanta_produced', 'photoelectrons_detected', 'electrons_detected')
 
 
 @export
@@ -49,7 +49,7 @@ class NRSource(fd.BlockModelSource):
         fd.MakeS2)
 
     final_dimensions = ('s1', 's2')
-    penultimate_dimensions = ('photoelectrons_detected', 'electrons_detected')
+    no_step_dimensions = ('quanta_produced', 'photoelectrons_detected', 'electrons_detected')
 
     # Use a larger default energy range, since most energy is lost
     # to heat.

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -440,8 +440,6 @@ class Source:
         if x in self.final_dimensions:
             return self._fetch(x, data_tensor=data_tensor)[:, o]
 
-        x_range = tf.cast(tf.range(self.dimsizes[x]),
-                          dtype=fd.float_type())[o, :]
         left_bound = self._fetch(x + '_min', data_tensor=data_tensor)[:, o]
         right_bound = self._fetch(x + '_max', data_tensor=data_tensor)[:, o]
         steps = tf.where((right_bound-left_bound+1) > self.dimsizes[x],

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -262,7 +262,8 @@ class Source:
         if dim in self.no_step_dimensions:
             pass
         else:
-            self.dimsizes[dim] = cap * np.greater(self.dimsizes[dim], cap) + self.dimsizes[dim] * np.less_equal(self.dimsizes[dim], cap)
+            self.dimsizes[dim] = cap * np.greater(self.dimsizes[dim], cap) + \
+                self.dimsizes[dim] * np.less_equal(self.dimsizes[dim], cap)
 
     def _calculate_dimsizes(self, max_dim_size):
         self.dimsizes = dict()
@@ -277,8 +278,7 @@ class Source:
             # Calculate steps if we have cappeed the dimesize
             steps = tf.where((ma-mi+1) > self.dimsizes[dim],
                              tf.math.ceil((ma-mi) / (self.dimsizes[dim]-1)),
-                             1).numpy() # We want to ceil this to ensure we cover to at
-                             # least the upper bound
+                             1).numpy()  # Cover to at least the upper bound
             # Store the steps in the dataframe
             d[dim + '_steps'] = steps
 

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -133,9 +133,9 @@ class Source:
         ctc += [x + '_min' for x in self.bonus_dimensions]  # Left bounds of domains
         ctc += [x + '_steps' for x in self.inner_dimensions]  # Step sizes
         ctc += [x + '_steps' for x in self.bonus_dimensions]  # Step sizes
-        ctc += [x + '_dimsizes' for x in self.inner_dimensions]  #
-        ctc += [x + '_dimsizes' for x in self.bonus_dimensions]  #
-        ctc += [x + '_dimsizes' for x in self.final_dimensions]  #
+        ctc += [x + '_dimsizes' for x in self.inner_dimensions]  # Dimension sizes
+        ctc += [x + '_dimsizes' for x in self.bonus_dimensions]  # Dimension sizes
+        ctc += [x + '_dimsizes' for x in self.final_dimensions]  # Dimension sizes
         ctc = list(set(ctc))
 
         self.column_index = fd.index_lookup_dict(ctc,
@@ -271,13 +271,15 @@ class Source:
             ma = d[dim + '_max'].to_numpy()
             mi = d[dim + '_min'].to_numpy()
             self.dimsizes[dim] = ma - mi + 1
+            # Ensure we don't go over max_dim_size in a domain
             self.cap_dimsizes(dim, max_dim_size)
 
+            # Calculate steps if we have cappeed the dimesize
             steps = tf.where((ma-mi+1) > self.dimsizes[dim],
                              tf.math.ceil((ma-mi) / (self.dimsizes[dim]-1)),
                              1).numpy() # We want to ceil this to ensure we cover to at
                              # least the upper bound
-            # Store the steps for later multiplying probabilities
+            # Store the steps in the dataframe
             d[dim + '_steps'] = steps
 
         for dim in self.final_dimensions:
@@ -286,6 +288,7 @@ class Source:
         # Calculate all custom dimsizes
         self.calculate_dimsizes_special()
 
+        # Store the dimsizes in the dataframe
         for dim in self.inner_dimensions:
             d[dim + "_dimsizes"] = self.dimsizes[dim]
         for dim in self.bonus_dimensions:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -661,3 +661,6 @@ class ColumnSource(Source):
     def random_truth(self, n_events, fix_truth=None, **params):
         print(f"{self.__class__.__name__} cannot generate events, skipping")
         return pd.DataFrame()
+
+    def calculate_dimsizes_special(self):
+        pass

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -31,8 +31,8 @@ class Source:
     # Final observable dimensions; for use in domain / cross-domain
     final_dimensions = tuple()
 
-    # Penultimate model dimensions; avoid variable stepping over these
-    penultimate_dimensions = tuple()
+    # Model dimensions to avoid variable stepping over the bounds
+    no_step_dimensions = tuple()
 
     # List all columns that are manually _fetch ed here
     # These will be added to the data_tensor even when the model function
@@ -82,7 +82,7 @@ class Source:
                  data=None,
                  batch_size=10,
                  max_sigma=3,
-                 max_dim_size=70,
+                 max_dim_size=100,
                  data_is_annotated=False,
                  _skip_tf_init=False,
                  _skip_bounds_computation=False,
@@ -95,7 +95,7 @@ class Source:
         :param batch_size: Number of events / tensorflow batch
         :param max_sigma: Hint for hidden variable bounds computation
         :param max_dim_size: Maximum bounds size for inner_dimensions,
-            excluding penultimate_dimensions
+            excluding no_step_dimensions
         :param data_is_annotated: If True, skip annotation
         :param _skip_tf_init: If True, skip tensorflow cache initialization
         :param _skip_bounds_computation: If True, skip bounds compuation
@@ -256,7 +256,7 @@ class Source:
             ma = self._fetch(dim + '_max')
             mi = self._fetch(dim + '_min')
             self.dimsizes[dim] = int(tf.reduce_max(ma - mi + 1).numpy())
-            if (self.dimsizes[dim] > max_dim_size) and (dim not in self.penultimate_dimensions):
+            if (self.dimsizes[dim] > max_dim_size) and (dim not in self.no_step_dimensions):
                 self.dimsizes[dim] = max_dim_size
         for dim in self.final_dimensions:
             self.dimsizes[dim] = 1

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -131,7 +131,6 @@ class Source:
         ctc += [x + '_min' for x in self.inner_dimensions]  # Left bounds of domains
         ctc += [x + '_max' for x in self.inner_dimensions]  # Right bounds of domains
         ctc += [x + '_min' for x in self.bonus_dimensions]  # Left bounds of domains
-        ctc += [x + '_max' for x in self.bonus_dimensions]  # Right bounds of domains
         ctc = list(set(ctc))
 
         self.column_index = fd.index_lookup_dict(ctc,

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -83,7 +83,7 @@ class Source:
 
     def __init__(self,
                  data=None,
-                 batch_size=1,
+                 batch_size=10,
                  max_sigma=3,
                  max_dim_size=70,
                  data_is_annotated=False,
@@ -475,7 +475,7 @@ class Source:
         # Cover the bounds range in integer steps not necessarily of 1
         left_bound = self._fetch(x + '_min', data_tensor=data_tensor)[:, o]
         steps = self._fetch(x + '_steps', data_tensor=data_tensor)[:, o]
-        x_range = tf.range(tf.reduce_sum(self._fetch(x + '_dimsizes', data_tensor=data_tensor))) * steps
+        x_range = tf.range(tf.reduce_max(self._fetch(x + '_dimsizes', data_tensor=data_tensor))) * steps
         return left_bound + x_range
 
     def cross_domains(self, x, y, data_tensor):

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -31,6 +31,9 @@ class Source:
     # Final observable dimensions; for use in domain / cross-domain
     final_dimensions = tuple()
 
+    # Penultimate model dimensions; avoid variable stepping over these
+    penultimate_dimensions = tuple()
+
     # List all columns that are manually _fetch ed here
     # These will be added to the data_tensor even when the model function
     # inspection will not find them.
@@ -79,6 +82,7 @@ class Source:
                  data=None,
                  batch_size=10,
                  max_sigma=3,
+                 max_dim_size=70,
                  data_is_annotated=False,
                  _skip_tf_init=False,
                  _skip_bounds_computation=False,
@@ -90,15 +94,18 @@ class Source:
         :param data: Dataframe with events to use in the inference
         :param batch_size: Number of events / tensorflow batch
         :param max_sigma: Hint for hidden variable bounds computation
+        :param max_dim_size: Maximum bounds size for inner_dimensions,
+            excluding penultimate_dimensions
         :param data_is_annotated: If True, skip annotation
         :param _skip_tf_init: If True, skip tensorflow cache initialization
         :param _skip_bounds_computation: If True, skip bounds compuation
         :param fit_params: List of parameters to fit
         :param progress: whether to show progress bars for mu estimation
-          (if data is not None)
+            (if data is not None)
         :param params: New defaults to use
         """
         self.max_sigma = max_sigma
+        self.max_dim_size = max_dim_size
 
         # Check for duplicated model functions
         for attrname in ['model_functions', 'special_model_functions']:

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -63,7 +63,7 @@ def lookup_axis1(x, indices, fill_value=0):
     # Convert indices to legal indices in flat array
     indices = tf.clip_by_value(indices, 0., tf.cast(b, dtype=float_type())-1.)
     indices = indices + tf.cast(b, dtype=float_type()) * \
-    tf.range(a, dtype=float_type())[:, o, o]
+        tf.range(a, dtype=float_type())[:, o, o]
     indices = tf.reshape(indices, shape=(-1,))
     indices = tf.dtypes.cast(indices, dtype=int_type())
 

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -53,15 +53,17 @@ def lookup_axis1(x, indices, fill_value=0):
        returning fill_value for out-of-range indices.
     """
     # Save shape of x and flatten
-    ind_shape = indices.shape
-    a, b = x.shape
+    ind_shape = tf.shape(indices)
+    a = tf.shape(x)[0]
+    b = tf.shape(x)[1]
     x = tf.reshape(x, [-1])
 
-    legal_index = indices < b
+    legal_index = tf.cast(indices, dtype=int_type()) < b
 
     # Convert indices to legal indices in flat array
-    indices = tf.clip_by_value(indices, 0., b - 1.)
-    indices = indices + b * tf.range(a, dtype=float_type())[:, o, o]
+    indices = tf.clip_by_value(indices, 0., tf.cast(b, dtype=float_type())-1.)
+    indices = indices + tf.cast(b, dtype=float_type()) * \
+    tf.range(a, dtype=float_type())[:, o, o]
     indices = tf.reshape(indices, shape=(-1,))
     indices = tf.dtypes.cast(indices, dtype=int_type())
 


### PR DESCRIPTION
Summary [here ](https://docs.google.com/presentation/d/1b4xh2-nUhBhnscXNoUEcthufW74W4wGHXgzD52QBe4Q/edit?usp=sharing)

This PR implements variable stepping into Flamedisx, for both the current default models and any future sets of models (i.e. the NEST models which I will port over next).

This was a LOT more work than I had envisaged: this is due to the way that the FD default models relate the energy spectrum to the quanta tensor, and the associated issues that variable stepping caused there. It wasn't an issue present in the NEST version, so I hadn't had to solve it until now. 

The slides should summarise this, the solution, the implementation of the stepping and the various other features I had to implement to get around this problem. I have tried to keep those features very generalised so they may be of use to others in the future!