### PR TITLE
Linear and geometric domain stepping

### DIFF
--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -25,6 +25,7 @@ class Block:
     array_columns: ty.Tuple[str] = tuple()
     frozen_model_functions: ty.Tuple[str] = tuple()
     model_attributes: ty.Tuple[str] = tuple()
+    stepping_exceptions: ty.Tuple[ty.Tuple[str, str]] = tuple()
 
     def __init__(self, source):
         self.source = source
@@ -152,7 +153,8 @@ class BlockModelSource(fd.Source):
             'special_model_functions',
             'model_attributes',
             'frozen_model_functions',
-            'array_columns')}
+            'array_columns',
+            'stepping_exceptions')}
 
         # Instantiate the blocks.
         self.model_blocks = tuple([b(self) for b in self.model_blocks])
@@ -223,6 +225,7 @@ class BlockModelSource(fd.Source):
             if ((d not in self.final_dimensions)
                 and (d not in self.model_blocks[0].dimensions))])
         self.initial_dimensions = self.model_blocks[0].dimensions
+        self.stepping_exceptions = tuple(collected['stepping_exceptions'])
 
         super().__init__(*args, **kwargs)
 

--- a/flamedisx/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/lxe_blocks/quanta_splitting.py
@@ -16,6 +16,11 @@ class MakePhotonsElectronsBinomial(fd.Block):
     depends_on = ((('quanta_produced',), 'rate_vs_quanta'),)
     dimensions = ('electrons_produced', 'photons_produced')
 
+    # This block does lookups into the quanta_produced dimension.
+    # Unless we make the lookup very clever, quanta_produced must be
+    # naturally stepped.
+    stepping_exceptions = (('quanta_produced', 'force_natural'),)
+
     special_model_functions = ('p_electron',)
     model_functions = special_model_functions
 


### PR DESCRIPTION
This is an alternate variable stepping implementation for comparison with #127. The aim is to support geometric stepping and avoid some possible issues mentioned in https://github.com/FlamTeam/flamedisx/pull/127#issuecomment-833937326.

Summary:
  * `Source.__init__` gets new `max_dim_size` and `stepping` arguments.
  * When data is set, min/max bounds are computed as usual, but the `dimsize`s, i.e. the requested size of each internal dimension, is  capped to `max_dim_size`.
  * For each event, we use the domain `linspace(min, max, dimsize)` or `geomspace(min, max, dimsize)` (depending on whether `stepping` is `'linear'` or `geometric`), rounded to integers. This may skip or duplicate numbers.
    * In master, we use `arange(min, min + dimsize - 1, dimsize)`. This effectively extends 'max' for each event to `min + dimsize - 1` (where `dimsize` is determined by the event with the largest max-min difference), which might cause interesting biases at low `max_sigma`, since we extend max but not min.
  * We calculate a block as usual, using these irregularly-spaced domains.
  * Finally, we apply a weighting to the block results, corresponding to the distance between domain elements: `1 + (d_prev-1)/2 + (d_next-1)/2` where `d_prev` and `d_next` are the distances to the next element in the domain. This is 1 for normal single-spaced domains, and 0 for values in between two duplicates. The weight of a gap of omitted numbers is divided equally between the endpoints on either side.
    * As in #127, each dimension is only upweighted like this once in the whole flamedisx computation.

Here's an example. Suppose for some event and dimension we have min=1, max=8, `stepping = 'linear'` and `max_dimsize = 5`. (Of course `max_dimsize` should never be this low in real life!) Then:
```  
True domain:            1   2   3   4   5   6   7   8
Linear stepping:        1    2.75    4.5     6.25   8
Rounded:                1       3   4       6       8
------------------------------------------------------
Weight:                1.5     1.5 1.5      2      1.5
(sum of weights = 8)
```

For comparison with #127, this:
  * Allows geometric as well as linear stepping. If we want to add more complex stepping algorithms, we just have to add the domain computation; the reweighting supports any domain.
  * Does not make the size of internal tensors variable across batches. I'm guessing fixed batch sizes is more efficient, but we can certainly try sorting events by `max-min` and allowing variable batch sizes later as an optimization.
  * Does not introduce `bonus_dimensions`, `extra_dimensions`, `_domain_dict_bonus`, etc. We will probably still want (some of) these for the NEST sources.

TODO:
  * For events with max-min+1 <= dimsize (whether dimsize is capped or not), extend min and max symmetrically so simple 1-space stepping can be used for them. This will improve accuracy: rather than wasting computation time computing 0 or 0.5-weighted duplicate elements, we will make flamedisx a bit more accurate at low max_sigma.
  * Test that it actually works! (beyond simple unit tests)
  * Show accuracy / performance tradeoff for linear, geometric, and no stepping.
