### PR TITLE
fix s2 acceptance and force float in map reading

### DIFF
--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -28,7 +28,7 @@ class InterpolateAndExtrapolate:
         averaging. Default is 2 * dimensions of points.
         """
         self.kdtree = cKDTree(points)
-        self.values = values
+        self.values = values.astype(np.float)
         if neighbours_to_use is None:
             neighbours_to_use = points.shape[1] * 2
         self.neighbours_to_use = neighbours_to_use

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -294,10 +294,13 @@ class SR1Source:
     def s2_acceptance(self,
                       s2,
                       cs2,
+                      s2_min=200,
+                      # Needed for future sources i.e. wall
                       cs2b_min=50.1,
                       cs2b_max=7940.):
         cs2b = cs2*(1-DEFAULT_AREA_FRACTION_TOP)
-        acceptance = tf.where((cs2b > cs2b_min) & (cs2b < cs2b_max),
+        acceptance = tf.where((cs2b > cs2b_min) & (cs2b < cs2b_max) 
+                                                & (s2 > s2_min),
                               tf.ones_like(s2, dtype=fd.float_type()),
                               tf.zeros_like(s2, dtype=fd.float_type()))
 

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -294,7 +294,7 @@ class SR1Source:
     def s2_acceptance(self,
                       s2,
                       cs2,
-                      s2_min=200,
+                      s2_min=200.,
                       # Needed for future sources i.e. wall
                       cs2b_min=50.1,
                       cs2b_max=7940.):


### PR DESCRIPTION
Small pull request to fix the SR1 S2 acceptance to account for the S2<200pe necessary for sources that produce low S2s and force the map reading to read floats. 