### PR TITLE
Documentation update: source attributes, block system, sphinx docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ docs/_build
 # Pycharm
 .idea
 
+# Visual studio code
+.vscode
+
 # coverage
 .coverage
 

--- a/docs/source/blocks.rst
+++ b/docs/source/blocks.rst
@@ -52,7 +52,14 @@ Flamedisx's sources are built from units called **blocks**. Each block takes car
 
 Each block is represented by a :py:class:`~flamedisx.block_source.Block` class, which has three main methods:
 
-* :py:meth:`~flamedisx.block_source.Block._compute` is a block's main method. This returns a factor in the deterministic differential rate computation; for example, the probability of seeing the observed S2 for a range of possible number of detected electrons.
+* :py:meth:`~flamedisx.block_source.Block._compute` is a block's main method. This returns a factor in the deterministic differential rate computation; for example, the probability of seeing the observed S2 for a range of possible number of detected electrons. :py:meth:`~flamedisx.block_source.Block._compute` gets several arguments:
+
+  * `data_tensor` and `ptensor`: don't worry about these, just pass them to `gimme` when you call model functions -- see `Model functions`_ below.
+
+  * Keyword arguments with the (cross-)domains of the block -- see `Block dimensions`_ below.
+
+  * For blocks with dependencies, keyword arguments of the dependency's domain and result -- see `Block dependencies`_ below.
+
 * The :py:meth:`~flamedisx.block_source.Block._simulate` method performs a Monte Carlo simulation of the block's process. For example, drawing one possible S2 integral value, given a simulated event of a certain number of detected electrons.
 
   * Simulated events have a special `p_accepted` column, starting out at 1.0 for each event. Blocks can multiply this with probabilities for passing various selections. At the end of the simulation, a random number will be drawn to determine whether each event actually passes the selections.
@@ -62,7 +69,7 @@ Each block is represented by a :py:class:`~flamedisx.block_source.Block` class, 
 Think of `_simulate` as going in the physical/causal direction, `_annotate` as going backwards, and `_compute` as a (usually) direction-independent description of the process.
 
 Most blocks in a source can be computed independently of the other blocks. The results of different blocks are matrix-multiplied together, representing convolution over hidden variables (such as number of produced electrons).
- 
+
 A few blocks instead directly take the result of another block and turn it into something else in the compute step. For example, `MakeNRQuanta` takes in an energy spectrum and converts it into a spectrum vs. number of produced quanta in the nuclear recoil process.
 
 
@@ -74,18 +81,57 @@ This is the easy part: inherit from :py:class:`~flamedisx.block_source.BlockMode
 
 The source will operate as follows:
  * When **computing** differential rates, we run a tensorflow graph that includes the `_compute` of all the blocks. If a block has dependencies, it's compute will of course be later in the graph than that of its dependents.
-  * During **simulation**, we run `_simulate` of the blocks in the order you specified in `model_blocks`, starting with the first block. This is usually the block that creates the energy spectrum.
-  * When **setting data** (e.g. when you create the source), we run `_annotate` of the blocks in reverse order. This way, you can first estimate hidden variables close to observables, then use those estimates for guessing deeper hidden variables. For example, you can use the estimated number of detected electrons to estimate the number of produced electrons.
+ * During **simulation**, we run `_simulate` of the blocks in the order you specified in `model_blocks`, starting with the first block. This is usually the block that creates the energy spectrum.
+ * When **setting data** (e.g. when you create the source), we run `_annotate` of the blocks in reverse order. This way, you can first estimate hidden variables close to observables, then use those estimates for guessing deeper hidden variables. For example, you can use the estimated number of detected electrons to estimate the number of produced electrons.
 
-
-Blocks in detail
--------------------
 
 Besides the main three methods, blocks usually specify additional attributes that describe their behavior to the source.
 
-Static attributes
-=================
-`model_attributes` is a tuple of strings of Block attributes that should be exposed in the source. Setting one of these attributes in the Source will override their value.
+
+
+Block dimensions
+----------------
+
+The `dimensions` tuple names the dimensions of the `_compute` output. Without this we wouldn't know how to combine the results of blocks. The batch/event dimension is not named.
+
+`_compute` will get a keyword argument for each of the dimensions you list here, containing a tensor with all possible values (the domain) of the dimension. If your block has two dimensions, each will be a 2d tensor; see :py:meth:`~flamedisx.source.Source.cross_domains`.
+
+For example:
+  * For :py:class:`~flamedisx.lxe_blocks.energy_spectrum.FixedShapeEnergySpectrum`, this is `('deposited_energy',)`, since `_compute` outputs a one-dimensional array per event, the differential rate as a function of deposited energy.
+  * For :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakePhotonsElectronsBinomial`, this is `('electrons_produced', 'photons_produced')`, since it outputs a two-dimensional array per event, the differential rate as a function of the produced number of photons and electrons.
+
+
+
+Model functions
+---------------
+
+The `model_functions` and `special_model_functions` attributes list Block methods that should become part of the `Source`. Users can override these in their custom sources without having to worry about which block provided which function.
+
+As an example, the :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakeNRQuanta` block exposes a :py:meth:`~flamedisx.lxe_blocks.quanta_generation.MakeNRQuanta.lindhard_l` model function that parametrizes the Lindhard process (nuclear recoil energy losses as heat) as a function of energy. Sources using this block can define a new `lindhard_l` method to override this. The modelling sections of the tutorial illustrate model function overriding in detail.
+
+You can find string-tuples of all regular and special model functions for a source in the `.model_functions` attribute. (Special model functions are also listed here, and separately in `.special_model_functions`.)
+
+As illustrated in the tutorial, positional arguments to model functions represent columns from the data, and keyword arguments represent parameters for which users can change the defaults and float in their fits.
+
+Never call a model function directly from your block's code! Instead, call model functions as follows:
+  * In `_compute`, call `self.gimme('your_model_function', data_tensor=data_tensor, ptensor=ptensor)`.
+  * In `_simulate` and `_annotate`, call `self.gimme_numpy('your_model_function')`.
+
+This takes care of several things:
+  * Positional arguments are filled in with columns from the data;
+  * Keyword arguments are filled in with inference parameters.
+  * For `gimme_numpy`, you will get back a numpy array (rather than a TensorFlow tensor).
+
+`special_model_functions` take an extra positional argument when they are called. It's up to you what this represents; usually this is used to pass hidden variables. The extra argument (called `bonus_arg` in flamedisx code) is passed as the first argument after `self`.
+
+If a model function is 'special' in this way, you must list it in **both** model_functions and special_model_functions
+
+
+
+Model attributes
+----------------
+
+`model_attributes` is a tuple of strings of Block attributes that should become part of the source. Just like model functions, users can override these attributes in custom sources.
 
 For example, the :py:class:`~flamedisx.lxe_blocks.energy_spectrum.FixedShapeEnergySpectrum` block has the `energies` and `rates_vs_energy` attributes to specify the the source's discretized energy spectrum. The `ERSource` and `NRSource` both use this block, so you can write::
 
@@ -99,47 +145,13 @@ For example, the :py:class:`~flamedisx.lxe_blocks.energy_spectrum.FixedShapeEner
 
 to change the energy spectrum. This is simply another form of 'common customization', just like the more common model function overriding.
 
-Do not try to change static attributes after a source is initialized. They are called static for a reason. (If you change them despite this warning, the change will not be propagated from the `Source` to the `Block`, and code in the `Block` will still see the old attribute and cause you a headache.)
-
-You can find a string-tuple of all static attributes for a source in the `.model_attributes` attribute.
+Do not try to change model attributes after a source is initialized! (Such changes will not be propagated from the `Source` to the `Block`; code in the `Block` will still see the old attribute, and you will get a headache.)
 
 
-Model functions
-=================
+Block dependencies
+------------------
 
-Just like `model_attributes` exposes attributes, `model_functions` and `special_model_functions` expose methods to the source. Each are a tuple of strings of method names.
-
-In your block, you call model functions in different ways:
-  * In `_compute`, call `self.gimme('your_model_function', data_tensor=data_tensor, ptensor=ptensor)`.
-  * In `_simulate` and `_annotate`, call `self.gimme_numpy('your_model_function')`.
-
-This takes care of several things:
-  * Positional arguments are filled in with columns from the data;
-  * Keyword arguments are filled in with inference parameters.
-  * For `gimme_numpy`, you will get back a numpy array (rather than a TensorFlow tensor).
-Never call a model function directly from your block's code!
-
-`special_model_functions` take an extra positional argument when they are called. It's up to you what this represents; usually this is used to pass variables. The extra argument (called `bonus_arg` in flamedisx code) is passed as the first argument after `self`.
-
-If a model function is 'special' in this way, you must list it in **both** model_functions and special_model_functions
-
-As an example, the :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakeNRQuanta` block exposes a :py:meth:`~flamedisx.lxe_blocks.quanta_generation.MakeNRQuanta.lindhard_l` model function that parametrizes the Lindhard process (nuclear recoil energy losses as heat) as a function of energy. Sources using this block can define a new `lindhard_l` method to override this. The modelling sections of the tutorial illustrate model function overriding in detail.
-
-You can find string-tuples of all regular and special model functions for a source in the `.model_functions` attribute. (Special model functions are also listed here, and separately in `.special_model_functions`.)
-
-Dimensions
-=================
-
-The `dimensions` tuple names the dimensions of the `_compute` output. Without this we wouldn't know how to combine the results of blocks. The batch/event dimension is not named.
-
-For example:
-  * For :py:class:`~flamedisx.lxe_blocks.energy_spectrum.FixedShapeEnergySpectrum`, this is `('deposited_energy',)`, since `_compute` outputs a one-dimensional array per event, the differential rate as a function of deposited energy.
-  * For :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakePhotonsElectronsBinomial`, this is `('electrons_produced', 'photons_produced')`, since it outputs a two-dimensional array per event, the differential rate as a function of the produced number of photons and electrons.
-
-Dependencies
-=================
-
-Sometimes you can only compute a block once you know the result of another block. If so, specify this block in the `depends_on` tuple.
+In some cases you can only compute a block once you know the full result of another block. If so, specify this block in the `depends_on` tuple.
 
 For example, `depends_on = ((('quanta_produced',), 'rate_vs_quanta'),)` means the block needs the result of some block with `dimensions = ('quanta_produced',)`. Depending on the source, this could be provided by :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakeNRQuanta` or :py:class:`~flamedisx.lxe_blocks.quanta_generation.MakeERQuanta`.
 
@@ -147,7 +159,7 @@ The dependency result and its domain (i.e. the x-values corresponding to the y-v
 
 
 Block initialization / setup
-============================
+----------------------------
 
 Define a `setup` method if you want to do something when the block is initialized. You can:
 
@@ -158,8 +170,9 @@ You can not:
 
 * Use self.source and expect its attributes to already reflect their final states. The source is only fully functional after the block setup phase.
 
+
 Frozen functions and array columns
-===================================
+----------------------------------
 
 To be written -- see :py:class:`~flamedisx.lxe_sources.WIMPsource` for an example in the meantime.
 
@@ -168,7 +181,7 @@ To be written -- see :py:class:`~flamedisx.lxe_sources.WIMPsource` for an exampl
 The first block of a source
 -----------------------------
 
-This is usually the block specifying the energy spectrum. It is special in several ways. 
+This is usually the block specifying the energy spectrum. It is special in several ways.
 
 Some restrictions are relaxed:
   * It does not have a `_simulate` method.

--- a/docs/source/blocks.rst
+++ b/docs/source/blocks.rst
@@ -145,7 +145,7 @@ For example, the :py:class:`~flamedisx.lxe_blocks.energy_spectrum.FixedShapeEner
 
 to change the energy spectrum. This is simply another form of 'common customization', just like the more common model function overriding.
 
-Do not try to change model attributes after a source is initialized! (Such changes will not be propagated from the `Source` to the `Block`; code in the `Block` will still see the old attribute, and you will get a headache.)
+Behind the scenes, any attempt to get or set a Block's model attribute or model function will be redirected to the `Source` to which the block belongs. So you can safely do `self.some_attribute` rather than `self.source_some_attribute`; these are equivalent.
 
 
 Block dependencies

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -47,9 +47,8 @@ class Block:
     #: Frozen model functions defined in this block
     frozen_model_functions: ty.Tuple[str] = tuple()
 
-    #: Static attributes this Block will furnish the source with.
-    #: The can be overriden by Source subclassing just like model functions;
-    #: they should NOT be altered during block/source instantiation!
+    #: Additional attributes this Block will furnish the source with.
+    #: These can be overriden by Source attributes, just like model functions.
     model_attributes: ty.Tuple[str] = tuple()
 
     def __init__(self, source):

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -287,9 +287,8 @@ class BlockModelSource(fd.Source):
     def _find_block(blocks,
                     has_dim: ty.Union[list, tuple, set],
                     exclude: Block = None):
-        """Find a block with a dimension in allowed
-        Return (dimensions, b), or
-         raises BlockNotFoundError if no such block found.
+        """Find a block with a dimension in has_dim, other than the block in
+        exclude. Return (dimensions, b), or raises BlockNotFoundError.
         """
         for dims, b in blocks.items():
             if b is exclude:

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -16,20 +16,40 @@ class Block:
 
     For example, P(electrons_detected | electrons_produced).
     """
+    #: Names of dimensions of the block's compute result
     dimensions: ty.Tuple[str]
-    extra_dimensions: ty.Tuple[ty.Tuple[str, bool]]  # Any extra dimensions
-    # treated differently. Label true if they represent an internally
-    # contracted hidden variable (will be added to inner_dimenions, domain
-    # tensors will automatically be calculated), label false otherwise (will be
-    # added to bonus_dimensions, any additional domain tensors utilising them
-    # will need calculating via the block overriding _domain_dict_bonus())
 
-    depends_on: ty.Tuple[str] = tuple()
+    #: Additional dimensions used in the block computation.
+    #: Label True if they represent an internally contracted hidden variable;
+    #: these will be added to inner_dimensions so domain tensors are calculated
+    #: automatically.
+    #: Label False otherwise; these will be added to bonus_dimensions. Thus,
+    #: any additional domain tensors utilising them will need calculating via
+    #: the block overriding _domain_dict_bonus())
+    extra_dimensions: ty.Tuple[ty.Tuple[str, bool]]
 
+    #: Blocks whose result this block expects as an extra keyword
+    #: argument to compute. Specify as ((block_dims, argument_name), ...),
+    #: where block_dims is the dimensions-tuple of the block, and argument_name
+    #: the expected name of the compute keyword argument.
+    depends_on: ty.Tuple[ty.Tuple[ty.Tuple[str], str]] = tuple()
+
+    #: Names of model functions defined in this block
     model_functions: ty.Tuple[str] = tuple()
+
+    #: Names of model functions that take an additional first argument
+    #: ('bonus arg') defined in this block; must be a subset of model_functions
     special_model_functions: ty.Tuple[str] = tuple()
+
+    #: Names of columns this block expects to be array-valued
     array_columns: ty.Tuple[str] = tuple()
+
+    #: Frozen model functions defined in this block
     frozen_model_functions: ty.Tuple[str] = tuple()
+
+    #: Static attributes this Block will furnish the source with.
+    #: The can be overriden by Source subclassing just like model functions;
+    #: they should NOT be altered during block/source instantiation!
     model_attributes: ty.Tuple[str] = tuple()
 
     def __init__(self, source):
@@ -160,8 +180,11 @@ class BlockModelSource(fd.Source):
     """Source whose model is split over different Blocks
     """
 
+    #: Blocks the source is built from.
+    #: simulate will be called from first to last, annotate from last to first.
     model_blocks: tuple
-    final_dimensions: tuple
+
+    #: Dimensions provided by the first block
     initial_dimensions: tuple
 
     def __init__(self, *args, **kwargs):

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -502,22 +502,22 @@ class LogLikelihood:
         """Return best-fit parameter dict
 
         :param guess: Guess parameters: dict {param: guess} of guesses to use.
-        Any omitted parameters will be guessed at LogLikelihood.defaults()
+            Any omitted parameters will be guessed at LogLikelihood.defaults()
         :param fix: dict {param: value} of parameters to keep fixed
-        during the minimzation.
+            during the minimzation.
         :param optimizer: 'tf', 'minuit' or 'scipy'
         :param get_lowlevel_result: Returns the full optimizer result instead
-        of the best fit parameters. Bool.
+            of the best fit parameters. Bool.
         :param get_history: Returns the history of optimizer calls instead
-        of the best fit parameters. Bool.
+            of the best fit parameters. Bool.
         :param use_hessian: If True, uses flamedisxs' exact Hessian
-        in the optimizer. Otherwise, most optimizers estimate it by finite-
-        difference calculations.
+            in the optimizer. Otherwise, most optimizers estimate it by finite-
+            difference calculations.
         :param return_errors: If using the minuit minimizer, instead return
-        a 2-tuple of (bestfit dict, error dict).
-        In case optimizer is minuit, you can also pass 'hesse' or 'minos' here.
+            a 2-tuple of (bestfit dict, error dict).
+            If the optimizer is minuit, you can also pass 'hesse' or 'minos'.
         :param allow_failure: If True, raise a warning instead of an exception
-        if there is an optimizer failure.
+            if there is an optimizer failure.
         """
         if bounds is None:
             bounds = dict()
@@ -605,36 +605,36 @@ class LogLikelihood:
             use_hessian=True,
             allow_failure=False,
     ):
-        """Return frequentist limit or confidence interval
+        """Return frequentist limit or confidence interval.
+
+        Returns a float (for upper or lower limits) or a 2-tuple of floats
+        (for a central interval)
 
         :param parameter: string, the parameter to set the interval on
         :param bestfit: {parameter: value} dictionary, global best-fit.
-        If omitted, will compute it using bestfit.
+            If omitted, will compute it using bestfit.
         :param guess: {param: value} guess of the result, or None.
-        If omitted, nuisance parameters will be guessed equal to bestfit.
-        If omitted, guess for target parameters will be based on asymptotic
-        parabolic computation.
+            If omitted, nuisance parameters will be guessed equal to bestfit.
+            If omitted, guess for target parameters will be based on asymptotic
+            parabolic computation.
         :param fix: {param: value} to fix during interval computation.
-        Result is only valid if same parameters were fixed for bestfit.
+            Result is only valid if same parameters were fixed for bestfit.
         :param confidence_level: Requried confidence level of the interval
         :param kind: Type of interval, 'upper', 'lower' or 'central'
         :param sigma_guess: Guess for one sigma uncertainty on the target
-        parameter. If not provided, will be computed from Hessian.
+            parameter. If not provided, will be computed from Hessian.
         :param t_ppf: returns critical value as function of parameter
-        Use Wilks' theorem if omitted.
+            Use Wilks' theorem if omitted.
         :param t_ppf_grad: return derivative of t_ppf
         :param t_ppf_hess: return second derivative of t_ppf
         :param tilt_overshoot: Set tilt so the limit's log likelihood will
-        overshoot the target value by roughly this much.
+            overshoot the target value by roughly this much.
         :param optimizer_kwargs: dict of additional arguments for optimizer
         :param allow_failure: If True, raise a warning instead of an exception
-        if there is an optimizer failure.
+            if there is an optimizer failure.
         :param use_hessian: If True, uses flamedisxs' exact Hessian
-        in the optimizer. Otherwise, most optimizers estimate it by finite-
-        difference calculations.
-
-        Returns a float (for upper or lower limits)
-        or a 2-tuple of floats (for a central interval)
+            in the optimizer. Otherwise, most optimizers estimate it by finite-
+            difference calculations.
         """
         if optimizer_kwargs is None:
             optimizer_kwargs = dict()

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -308,7 +308,6 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
     #: Number of time bins to use for annual modulation computation
     n_time_bins = 24
 
-
     #: Bin *edges* to use for energy histogram. Centers of the bins correspond
     #: to allowed energies.
     energy_edges = np.geomspace(0.7, 50, 100)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -29,11 +29,11 @@ class Source:
     #: rate computation
     trace_difrate = True
 
-    #: Names of model functions that take NO additional first argument
+    #: Names of model functions
     model_functions: ty.Tuple[str] = tuple()
 
-    #: Names of model functions that take one additional first argument
-    #: ('bonus arg')
+    #: Names of model functions that take an additional first argument
+    #: ('bonus arg'). This must be a subset of model_functions.
     special_model_functions: ty.Tuple[str] = tuple()
 
     #: Model functions whose results should be evaluated once per event,
@@ -464,6 +464,7 @@ class Source:
         return [self.batch_size, self.n_columns_in_data_tensor]
 
     def trace_differential_rate(self):
+        """Compile the differential rate computation to a tensorflow graph"""
         input_signature = (
             tf.TensorSpec(shape=self._batch_data_tensor_shape(),
                           dtype=fd.float_type()),
@@ -668,7 +669,11 @@ class ColumnSource(Source):
     """Source that expects precomputed differential rate in a column,
     and precomputed mu in an attribute
     """
+
+    #: Name of the data column containing the precomputed differential rate
     column = 'rename_me!'
+
+    #: Expected events for this source
     mu = 42.
 
     def extra_needed_columns(self):

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -386,13 +386,13 @@ class Source:
         :param fname: Name of the model function to compute
         :param bonus_arg: If fname takes a bonus argument, the data for it
         :param numpy_out: If True, return (tuple of) numpy arrays,
-        otherwise (tuple of) tensors.
+            otherwise (tuple of) tensors.
         :param data_tensor: Data tensor, columns as self.column_index
-        If not given, use self.data (used in annotate)
+            If not given, use self.data (used in annotate)
         :param ptensor: Parameter tensor, columns as self.param_id
-        If not give, use defaults dictionary (used in annotate)
-        Before using gimme, you must use set_data to
-        populate the internal caches.
+            If not given, use defaults dictionary (used in annotate)
+            Before using gimme, you must use set_data to
+            populate the internal caches.
         """
         assert (bonus_arg is not None) == (fname in self.special_model_functions)
         assert isinstance(fname, str), \
@@ -492,7 +492,7 @@ class Source:
     ##
 
     def domain(self, x, data_tensor=None):
-        """Return (n_events, |possible x values|) matrix containing all
+        """Return (n_events, n_x) matrix containing all
         possible integer values of x for each event.
 
         If x is a final dimension (e.g. s1, s2), we return an (n_events, 1)
@@ -508,7 +508,7 @@ class Source:
         return left_bound + x_range
 
     def cross_domains(self, x, y, data_tensor):
-        """Return (x, y) two-tuple of (n_events, |x|, |y|) tensors
+        """Return (x, y) two-tuple of (n_events, n_x, n_y) tensors
         containing possible integer values of x and y, respectively.
         """
         # TODO: somehow mask unnecessary elements and save computation time
@@ -560,7 +560,7 @@ class Source:
 
         Careful: ensure mutual constraints are accounted for first!
         (e.g. fixing energy for a modulating WIMP has consequences for the
-         time distribution.)
+        time distribution.)
         """
         if fix_truth is not None:
             for k, v in fix_truth.items():

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -203,7 +203,7 @@ def index_lookup_dict(names, column_widths=None):
      (tf.constant integers.)
 
     :param column_widths: dictionary mapping names to column width.
-    For columns with width > 1, the result contains a tensor slice.
+        For columns with width > 1, the result contains a tensor slice.
     """
     names = list(names)
     if column_widths is None:


### PR DESCRIPTION
This is a documentation update:

  * Add comments with `#:` for attributes of `Source`, `BlockSource`, and a few other classes. These will appear in our [API reference](https://flamedisx.readthedocs.io/en/latest/reference/flamedisx.html#module-flamedisx.source) after this is merged.
  * Fix some problems with the block system documentation:
    * Several subsection headings did not appear;
    * The arguments to `_compute ` were never described;
    * Model attributes, which are relatively rare, were more prominently documented than model functions and dimensions, which are both used in every block. They were also occasionally referred to as 'static attributes', their old name.
  * Fix a few docstrings that weren't compatible with sphinx, and thus looked weird in the API reference.