### PR TITLE
Test config

### DIFF
--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -28,7 +28,7 @@ class InterpolateAndExtrapolate:
         averaging. Default is 2 * dimensions of points.
         """
         self.kdtree = cKDTree(points)
-        self.values = values
+        self.values = values.astype(np.float)
         if neighbours_to_use is None:
             neighbours_to_use = points.shape[1] * 2
         self.neighbours_to_use = neighbours_to_use

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -158,6 +158,9 @@ class SR1Source:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def set_defaults(*args, **kwargs):
+        super().set_defaults(*args, **kwargs)
+
         # Yield maps
         self.s1_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s1_rly))
         self.s2_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s2_rly))

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -118,6 +118,7 @@ def calculate_reconstruction_efficiency(sig, fmap, domain_def, pivot_pt):
 ##
 class SR1Source:
     drift_velocity = DEFAULT_DRIFT_VELOCITY
+    default_elife = DEFAULT_ELECTRON_LIFETIME
 
     model_attributes = ('path_cut_accept_s1',
                         'path_cut_accept_s2',
@@ -127,6 +128,7 @@ class SR1Source:
                         'path_reconstruction_bias_mean_s2',
                         'path_reconstruction_efficiencies_s1',
                         'variable_elife',
+                        'default_elife',
                         'path_electron_lifetimes',
                         )
 
@@ -229,7 +231,7 @@ class SR1Source:
                 d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
                                         self.domain_def_elife)
             else:
-                d['elife'] = DEFAULT_ELECTRON_LIFETIME
+                d['elife'] = self.default_elife
 
         # Add cS1 and cS2 following XENON conventions.
         # Skip this if s1/s2 are not known, since we're simulating

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -1,6 +1,4 @@
 """XENON1T SR1 implementation"""
-import json
-
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -33,15 +31,15 @@ DEFAULT_SINGLE_ELECTRON_WIDTH = 0.25 * DEFAULT_SINGLE_ELECTRON_GAIN
 # Official numbers from BBF
 DEFAULT_S1_RECONSTRUCTION_BIAS_PIVOT = 0.5948841302444277
 DEFAULT_S2_RECONSTRUCTION_BIAS_PIVOT = 0.49198507921078005
-DEFAULT_S1_RECONSTRUCTION_EFFICIENCY_PIVOT = -0.31816407029454036 
+DEFAULT_S1_RECONSTRUCTION_EFFICIENCY_PIVOT = -0.31816407029454036
 
 
 def read_maps_tf(path_bag, is_bbf=False):
     """ Function to read reconstruction bias/combined cut acceptances/dummy maps.
     Note that this implementation fundamentally assumes upper and lower bounds
     have exactly the same domain definition.
-    :param path_bag: List with filenames of acceptance maps  
-    :param is_bbf: True if reading file from BBF folder. 
+    :param path_bag: List with filenames of acceptance maps
+    :param is_bbf: True if reading file from BBF folder.
     :return: List of acceptance maps and their domain definitions
     """
     data_bag = []
@@ -64,7 +62,7 @@ def interpolate_tf(sig_tf, fmap, domain):
     :return: Tensor of interpolated map values (same shape as x)
     """
     return tfp.math.interp_regular_1d_grid(x=sig_tf,
-            x_ref_min=domain[0], x_ref_max=domain[1], 
+            x_ref_min=domain[0], x_ref_max=domain[1],
             y_ref=fmap, fill_value='constant_extension')
 
 def calculate_reconstruction_bias(sig, fmap, domain_def, pivot_pt):
@@ -122,7 +120,7 @@ class SR1Source:
 
     model_attributes = ('path_cut_accept_s1',
                         'path_cut_accept_s2',
-                        'path_s1_rly', 
+                        'path_s1_rly',
                         'path_s2_rly',
                         'path_reconstruction_bias_mean_s1',
                         'path_reconstruction_bias_mean_s2',
@@ -133,30 +131,30 @@ class SR1Source:
                         )
 
     # Light yield maps
-    path_s1_rly = ('1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json')
-    path_s2_rly = ('1t_maps/XENON1T_s2_xy_ly_SR1_v2.2.json')
+    path_s1_rly = '1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json'
+    path_s2_rly = '1t_maps/XENON1T_s2_xy_ly_SR1_v2.2.json'
 
     # Combined cuts acceptances
     path_cut_accept_s1 = ('S1AcceptanceSR1_v7_Median.json',)
     path_cut_accept_s2 = ('S2AcceptanceSR1_v7_Median.json',)
 
     # Pax reconstruction bias maps
-    path_reconstruction_bias_mean_s1 = ('ReconstructionS1BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS1BiasMeanUppers_SR1_v2.json')
-    path_reconstruction_bias_mean_s2 = ('ReconstructionS2BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS2BiasMeanUppers_SR1_v2.json')
+    path_reconstruction_bias_mean_s1 = (
+        'ReconstructionS1BiasMeanLowers_SR1_v2.json',
+        'ReconstructionS1BiasMeanUppers_SR1_v2.json')
+    path_reconstruction_bias_mean_s2 = (
+        'ReconstructionS2BiasMeanLowers_SR1_v2.json',
+        'ReconstructionS2BiasMeanUppers_SR1_v2.json')
 
     # Pax reconstruction efficiency maps (do not reorder: Lowers, Medians, Uppers)
-    path_reconstruction_efficiencies_s1 = ('RecEfficiencyLowers_SR1_70phd_v1.json',
-                                       'RecEfficiencyMedians_SR1_70phd_v1.json',
-                                       'RecEfficiencyUppers_SR1_70phd_v1.json')
+    path_reconstruction_efficiencies_s1 = (
+        'RecEfficiencyLowers_SR1_70phd_v1.json',
+        'RecEfficiencyMedians_SR1_70phd_v1.json',
+        'RecEfficiencyUppers_SR1_70phd_v1.json')
 
     # Elife maps
     variable_elife = True
     path_electron_lifetimes = ('1t_maps/electron_lifetimes_sr1.json',)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def set_defaults(self, *args, **kwargs):
         super().set_defaults(*args, **kwargs)
@@ -295,7 +293,7 @@ class SR1Source:
                               tf.zeros_like(s1, dtype=fd.float_type()))
 
         # multiplying by combined cut acceptance
-        acceptance *= interpolate_tf(s1, 
+        acceptance *= interpolate_tf(s1,
                                      self.cut_accept_map_s1[0],
                                      self.cut_accept_domain_s1)
         return acceptance
@@ -311,7 +309,7 @@ class SR1Source:
                               tf.zeros_like(s2, dtype=fd.float_type()))
 
         # multiplying by combined cut acceptance
-        acceptance *= interpolate_tf(s2, 
+        acceptance *= interpolate_tf(s2,
                                      self.cut_accept_map_s2[0],
                                      self.cut_accept_domain_s2)
         return acceptance

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -133,34 +133,34 @@ class SR1Source:
                         )
 
     # Light yield maps
-    path_s1_rly = ['1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json']
-    path_s2_rly = ['1t_maps/XENON1T_s2_xy_ly_SR1_v2.2.json']
+    path_s1_rly = ('1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json')
+    path_s2_rly = ('1t_maps/XENON1T_s2_xy_ly_SR1_v2.2.json')
 
     # Combined cuts acceptances
-    path_cut_accept_s1 = ['S1AcceptanceSR1_v7_Median.json']
-    path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
+    path_cut_accept_s1 = ('S1AcceptanceSR1_v7_Median.json',)
+    path_cut_accept_s2 = ('S2AcceptanceSR1_v7_Median.json',)
 
     # Pax reconstruction bias maps
-    path_reconstruction_bias_mean_s1 = ['ReconstructionS1BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS1BiasMeanUppers_SR1_v2.json']
-    path_reconstruction_bias_mean_s2 = ['ReconstructionS2BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS2BiasMeanUppers_SR1_v2.json']
+    path_reconstruction_bias_mean_s1 = ('ReconstructionS1BiasMeanLowers_SR1_v2.json',
+                                    'ReconstructionS1BiasMeanUppers_SR1_v2.json')
+    path_reconstruction_bias_mean_s2 = ('ReconstructionS2BiasMeanLowers_SR1_v2.json',
+                                    'ReconstructionS2BiasMeanUppers_SR1_v2.json')
 
     # Pax reconstruction efficiency maps (do not reorder: Lowers, Medians, Uppers)
-    path_reconstruction_efficiencies_s1 = ['RecEfficiencyLowers_SR1_70phd_v1.json',
+    path_reconstruction_efficiencies_s1 = ('RecEfficiencyLowers_SR1_70phd_v1.json',
                                        'RecEfficiencyMedians_SR1_70phd_v1.json',
-                                       'RecEfficiencyUppers_SR1_70phd_v1.json']
+                                       'RecEfficiencyUppers_SR1_70phd_v1.json')
 
     # Elife maps
     variable_elife = True
-    path_electron_lifetimes = ['1t_maps/electron_lifetimes_sr1.json']
+    path_electron_lifetimes = ('1t_maps/electron_lifetimes_sr1.json',)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Yield maps
-        self.s1_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s1_rly[0]))
-        self.s2_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s2_rly[0]))
+        self.s1_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s1_rly))
+        self.s2_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s2_rly))
 
         # Loading combined cut acceptances
         self.cut_accept_map_s1, self.cut_accept_domain_s1 = \

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -35,40 +35,6 @@ DEFAULT_S1_RECONSTRUCTION_BIAS_PIVOT = 0.5948841302444277
 DEFAULT_S2_RECONSTRUCTION_BIAS_PIVOT = 0.49198507921078005
 DEFAULT_S1_RECONSTRUCTION_EFFICIENCY_PIVOT = -0.31816407029454036 
 
-##
-# Yield maps
-##
-s1_map, s2_map = [
-    fd.InterpolatingMap(fd.get_resource(fd.pax_file(x)))
-    for x in ('XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json',
-              'XENON1T_s2_xy_ly_SR1_v2.2.json')]
-
-##
-# Loading Pax reconstruction bias
-##
-path_reconstruction_bias_mean_s1 = ['ReconstructionS1BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS1BiasMeanUppers_SR1_v2.json']
-path_reconstruction_bias_mean_s2 = ['ReconstructionS2BiasMeanLowers_SR1_v2.json',
-                                    'ReconstructionS2BiasMeanUppers_SR1_v2.json']
-
-##
-# Pax reconstruction efficiencies (do not reorder: Lowers, Medians, Uppers)
-##
-path_reconstruction_efficiencies_s1 = ['RecEfficiencyLowers_SR1_70phd_v1.json',
-                                       'RecEfficiencyMedians_SR1_70phd_v1.json',
-                                       'RecEfficiencyUppers_SR1_70phd_v1.json']
-
-##
-# Loading combined cuts acceptances
-##
-path_cut_accept_s1 = ['S1AcceptanceSR1_v7_Median.json']
-path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
-
-##
-# Loading elife maps
-##
-variable_elife = True
-path_electron_lifetimes = ['1t_maps/electron_lifetimes_sr1.json']
 
 def read_maps_tf(path_bag, is_bbf=False):
     """ Function to read reconstruction bias/combined cut acceptances/dummy maps.
@@ -153,28 +119,66 @@ def calculate_reconstruction_efficiency(sig, fmap, domain_def, pivot_pt):
 class SR1Source:
     drift_velocity = DEFAULT_DRIFT_VELOCITY
 
+    model_attributes = ('path_cut_accept_s1',
+                        'path_cut_accept_s2',
+                        'path_s1_rly', 
+                        'path_s2_rly',
+                        'path_reconstruction_bias_mean_s1',
+                        'path_reconstruction_bias_mean_s2',
+                        'path_reconstruction_efficiencies_s1',
+                        'variable_elife',
+                        'path_electron_lifetimes',
+                        )
+
+    # Light yield maps
+    path_s1_rly = ['1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json']
+    path_s2_rly = ['1t_maps/XENON1T_s2_xy_ly_SR1_v2.2.json']
+
+    # Combined cuts acceptances
+    path_cut_accept_s1 = ['S1AcceptanceSR1_v7_Median.json']
+    path_cut_accept_s2 = ['S2AcceptanceSR1_v7_Median.json']
+
+    # Pax reconstruction bias maps
+    path_reconstruction_bias_mean_s1 = ['ReconstructionS1BiasMeanLowers_SR1_v2.json',
+                                    'ReconstructionS1BiasMeanUppers_SR1_v2.json']
+    path_reconstruction_bias_mean_s2 = ['ReconstructionS2BiasMeanLowers_SR1_v2.json',
+                                    'ReconstructionS2BiasMeanUppers_SR1_v2.json']
+
+    # Pax reconstruction efficiency maps (do not reorder: Lowers, Medians, Uppers)
+    path_reconstruction_efficiencies_s1 = ['RecEfficiencyLowers_SR1_70phd_v1.json',
+                                       'RecEfficiencyMedians_SR1_70phd_v1.json',
+                                       'RecEfficiencyUppers_SR1_70phd_v1.json']
+
+    # Elife maps
+    variable_elife = True
+    path_electron_lifetimes = ['1t_maps/electron_lifetimes_sr1.json']
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Yield maps
+        self.s1_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s1_rly[0]))
+        self.s2_map = fd.InterpolatingMap(fd.get_nt_file(self.path_s2_rly[0]))
+
         # Loading combined cut acceptances
         self.cut_accept_map_s1, self.cut_accept_domain_s1 = \
-            read_maps_tf(path_cut_accept_s1, is_bbf=True)
+            read_maps_tf(self.path_cut_accept_s1, is_bbf=True)
         self.cut_accept_map_s2, self.cut_accept_domain_s2 = \
-            read_maps_tf(path_cut_accept_s2, is_bbf=True)
+            read_maps_tf(self.path_cut_accept_s2, is_bbf=True)
 
         # Loading reconstruction efficiencies map
         self.recon_eff_map_s1, self.domain_def_ph = \
-            read_maps_tf(path_reconstruction_efficiencies_s1, is_bbf=True)
+            read_maps_tf(self.path_reconstruction_efficiencies_s1, is_bbf=True)
 
         # Loading reconstruction bias map
         self.recon_map_s1_tf, self.domain_def_s1 = \
-            read_maps_tf(path_reconstruction_bias_mean_s1, is_bbf=True)
+            read_maps_tf(self.path_reconstruction_bias_mean_s1, is_bbf=True)
         self.recon_map_s2_tf, self.domain_def_s2 = \
-            read_maps_tf(path_reconstruction_bias_mean_s2, is_bbf=True)
+            read_maps_tf(self.path_reconstruction_bias_mean_s2, is_bbf=True)
 
         # Loading electron lifetime map
         self.elife_tf, self.domain_def_elife = \
-            read_maps_tf(path_electron_lifetimes, is_bbf=False)
+            read_maps_tf(self.path_electron_lifetimes, is_bbf=False)
 
     def reconstruction_bias_s1(self,
                                s1,
@@ -209,10 +213,10 @@ class SR1Source:
 
     def add_extra_columns(self, d):
         super().add_extra_columns(d)
-        d['s2_relative_ly'] = s2_map(
+        d['s2_relative_ly'] = self.s2_map(
              np.transpose([d['x_observed'].values,
                           d['y_observed'].values]))
-        d['s1_relative_ly'] = s1_map(
+        d['s1_relative_ly'] = self.s1_map(
             np.transpose([d['x'].values,
                           d['y'].values,
                           d['z'].values]))
@@ -220,7 +224,7 @@ class SR1Source:
         # Not too good. patchy. event_time should be int since event_time in actual
         # data is int64 in ns. But need this to be float32 to interpolate.
         if 'elife' not in d.columns:
-            if variable_elife:
+            if self.variable_elife:
                 d['event_time'] = d['event_time'].astype('float32')
                 d['elife'] = interpolate_tf(d['event_time'], self.elife_tf[0],
                                         self.domain_def_elife)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -158,7 +158,7 @@ class SR1Source:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def set_defaults(*args, **kwargs):
+    def set_defaults(self, *args, **kwargs):
         super().set_defaults(*args, **kwargs)
 
         # Yield maps


### PR DESCRIPTION
As a follow-up test suggested by @JelleAalbers in https://github.com/FlamTeam/flamedisx/pull/140#issuecomment-864475656, the main changes in this PR occur in `x1t_sr1.py` the paths of the elife, cut efficiency, reconstruction bias mean, etc maps are moved inside `class SR1Source` so that the map paths are configurable as well.

The change in `itp_map.py` insists of specific type casting of the map values so that the new nT maps could be read in as well.

The changes are then tested on a local machine with 
```
class newSource(fd.SR1ERSource):
       # overwriting some methods

specificSource = newSource(config=my_config_path)
specificSource.print_config(column_widths=(40, 99))
```
returning the output shown in the screenshot, which displayed the expected values.
![Screenshot from 2021-06-28 19-06-14](https://user-images.githubusercontent.com/46324102/123676285-0947ac80-d844-11eb-9282-8b1c69605830.png)