### PR TITLE
Various bug fixes for NEST sources.

### DIFF
--- a/flamedisx/lux/lux.py
+++ b/flamedisx/lux/lux.py
@@ -7,6 +7,7 @@ import configparser
 import os
 
 import flamedisx as fd
+from .. import nest as fd_nest
 
 export, __all__ = fd.exporter()
 
@@ -30,10 +31,10 @@ class LUXSource:
         self.z_topDrift = config.getfloat('NEST', 'z_topDrift_config')
         self.dt_cntr = config.getfloat('NEST', 'dt_cntr_config')
 
-        self.density = fd.calculate_density(
+        self.density = fd_nest.calculate_density(
             config.getfloat('NEST', 'temperature_config'),
             config.getfloat('NEST', 'pressure_config')).item()
-        self.drift_velocity = fd.calculate_drift_velocity(
+        self.drift_velocity = fd_nest.calculate_drift_velocity(
          config.getfloat('NEST', 'drift_field_config'),
          self.density,
          config.getfloat('NEST', 'temperature_config')).item()

--- a/flamedisx/nest/lxe_blocks/pe_detection.py
+++ b/flamedisx/nest/lxe_blocks/pe_detection.py
@@ -27,6 +27,10 @@ class DetectS1Photoelectrons(fd.Block):
                 probs=tf.cast(p_det, dtype=fd.float_type())
             ).prob(s1_photoelectrons_detected)
 
+        result = tf.where(tf.math.is_nan(result),
+                          tf.zeros_like(result, dtype=fd.float_type()),
+                          result)
+
         return result
 
     def _simulate(self, d):
@@ -47,9 +51,9 @@ class DetectS1Photoelectrons(fd.Block):
             _nprod_temp * _pdet_temp,
             _pdet_temp)
         # TODO: this assumes the spread from the PE detection efficiency is subdominant
+        # TODO: come back and fix thing with p_det_mle
         for suffix, intify in (('min', np.floor),
                                ('max', np.ceil),
                                ('mle', np.round)):
             d['s1_photoelectrons_produced_' + suffix] = \
-                intify(d['s1_photoelectrons_detected_' + suffix].values
-                       / p_det_mle)
+                intify(d['s1_photoelectrons_detected_' + suffix].values)

--- a/flamedisx/nest/lxe_blocks/pe_detection.py
+++ b/flamedisx/nest/lxe_blocks/pe_detection.py
@@ -42,14 +42,14 @@ class DetectS1Photoelectrons(fd.Block):
 
     def _annotate(self, d):
         # Estimate the mle of the detection probability via interpolation
-        _nprod_temp = np.logspace(-1., 8., 1000)
-        _pdet_temp = self.gimme_numpy(
-            'photoelectron_detection_eff',
-            _nprod_temp)
-        p_det_mle = np.interp(
-            d['s1_photoelectrons_detected_mle'],
-            _nprod_temp * _pdet_temp,
-            _pdet_temp)
+        # _nprod_temp = np.logspace(-1., 8., 1000)
+        # _pdet_temp = self.gimme_numpy(
+        #     'photoelectron_detection_eff',
+        #     _nprod_temp)
+        # p_det_mle = np.interp(
+        #     d['s1_photoelectrons_detected_mle'],
+        #     _nprod_temp * _pdet_temp,
+        #     _pdet_temp)
         # TODO: this assumes the spread from the PE detection efficiency is subdominant
         # TODO: come back and fix thing with p_det_mle
         for suffix, intify in (('min', np.floor),

--- a/flamedisx/nest/lxe_blocks/secondary_quanta_generation.py
+++ b/flamedisx/nest/lxe_blocks/secondary_quanta_generation.py
@@ -38,11 +38,11 @@ class MakeS2Photons(fd.Block):
         return result
 
     def _simulate(self, d):
-        d['s2_photons_produced'] = tf.cast(tf.math.round(stats.norm.rvs(
+        d['s2_photons_produced'] = np.round(stats.norm.rvs(
             loc=(d['electrons_detected']
                  * self.gimme_numpy('electron_gain_mean')),
             scale=(d['electrons_detected']**0.5
-                   * self.gimme_numpy('electron_gain_std')))), dtype=fd.int_type())
+                   * self.gimme_numpy('electron_gain_std')))).astype(int)
 
     def _annotate(self, d):
         m = self.gimme_numpy('electron_gain_mean')

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -180,7 +180,8 @@ class nestERSource(nestSource):
         return fd.safe_p(qy * 13.7e-3)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ()
+    no_step_dimensions = ('s1_photoelectrons_produced',
+                          's1_photoelectrons_detected')
 
 
 @export
@@ -203,7 +204,8 @@ class nestNRSource(nestSource):
         fd_nest.MakeS2)
 
     final_dimensions = ('s1', 's2')
-    no_step_dimensions = ()
+    no_step_dimensions = ('s1_photoelectrons_produced',
+                          's1_photoelectrons_detected')
 
     # Use a larger default energy range, since most energy is lost
     # to heat.


### PR DESCRIPTION
Some small bug fixes for the NEST sources:

- Fix syntax in LUX sources after Jelle's changes
- Avoid S1 photoelectron detection binomial returning `nan`
- Temporary fix to `_annotate()` in pe_detection.py: will return to properly fix this later
- Fix where one block was accidentally using TensorFlow for `simulate()`
- No stepping for the sharply peaked S1 photoelectron detection binomial