### PR TITLE
bug fix in add_extra_columns to only add cs1, cs2 for simulated events

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -277,13 +277,11 @@ class SR1Source:
         # Add cS1 and cS2 following XENON conventions.
         # Skip this if s1/s2 are not known, since we're simulating
         # TODO: This is a kludge...
-        if 's1' in d.columns:
+        if ('s1' in d.columns) and ('cs1' not in d.columns):
             d['cs1'] = d['s1'] / d['s1_relative_ly']
-        if 's2' in d.columns:
-            d['cs2'] = (
-                d['s2']
-                / d['s2_relative_ly']
-                * np.exp(d['drift_time'] / d['elife']))
+        if ('s2' in d.columns) and ('cs2' not in d.columns):
+            d['cs2'] = (d['s2'] / d['s2_relative_ly']
+                      * np.exp(d['drift_time'] / d['elife']))
 
 
     @staticmethod


### PR DESCRIPTION
This pull request fixes a bug in `add_extra_columns` and updates the conditions under which `cs1` and `cs2` are computed so that they are only computed for the simulated events and not replaced in actual data.