### PR TITLE
Fix hessian bug

### DIFF
--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -626,8 +626,11 @@ class IntervalObjective(Objective):
 
         if sigma_guess is None:
             # Estimate one sigma interval using parabolic approx.
+            # inverse_hessian returns hessian of -2 loglikelihood but the
+            # covariance matrix is calculated from the hessian of -
+            # loglikelihood
             sigma_guess = fd.cov_to_std(
-                self.lf.inverse_hessian(bestfit)
+                2. * self.lf.inverse_hessian(bestfit)
             )[0][self.arg_names.index(self.target_parameter)]
         self.sigma_guess = sigma_guess
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -626,11 +626,11 @@ class IntervalObjective(Objective):
 
         if sigma_guess is None:
             # Estimate one sigma interval using parabolic approx.
-            # inverse_hessian returns hessian of -2 loglikelihood but the
-            # covariance matrix is calculated from the hessian of the
-            # - loglikelihood
+            # `inverse_hessian` returns inverse of the hessian of -2 loglikelihood
+            # but the covariance matrix is the inverse of the hessian of - loglikelihood
+            # (k A)^(-1) = k^(-1)A^(-1)
             sigma_guess = fd.cov_to_std(
-                0.5 * self.lf.inverse_hessian(bestfit)
+                2. * self.lf.inverse_hessian(bestfit)
             )[0][self.arg_names.index(self.target_parameter)]
         self.sigma_guess = sigma_guess
 

--- a/flamedisx/inference.py
+++ b/flamedisx/inference.py
@@ -627,10 +627,10 @@ class IntervalObjective(Objective):
         if sigma_guess is None:
             # Estimate one sigma interval using parabolic approx.
             # inverse_hessian returns hessian of -2 loglikelihood but the
-            # covariance matrix is calculated from the hessian of -
-            # loglikelihood
+            # covariance matrix is calculated from the hessian of the
+            # - loglikelihood
             sigma_guess = fd.cov_to_std(
-                2. * self.lf.inverse_hessian(bestfit)
+                0.5 * self.lf.inverse_hessian(bestfit)
             )[0][self.arg_names.index(self.target_parameter)]
         self.sigma_guess = sigma_guess
 

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -740,7 +740,7 @@ class LogLikelihood:
         return np.linalg.inv(-2 * grad2_ll)
 
     def summary(self, bestfit=None, fix=None, guess=None,
-                inverse_hessian=None, precision=3):
+                cov=None, precision=3):
         """Print summary information about best fit"""
         if fix is None:
             fix = dict()
@@ -748,15 +748,15 @@ class LogLikelihood:
             bestfit = self.bestfit(guess=guess, fix=fix)
 
         params = {**bestfit, **fix}
-        if inverse_hessian is None:
+        if cov is None:
             # inverse_hessian returns inverse of hessian of -2 loglikelihood
             # but covariance matrix is inverse of hessian of - logikelihood
             # (kA)^(-1) = k^(-1)A^(-1) for non-zero scalar k
-            inverse_hessian = 2. * self.inverse_hessian(
+            cov = 2. * self.inverse_hessian(
                 params,
                 omit_grads=tuple(fix.keys()))
 
-        stderr, corr = cov_to_std(inverse_hessian)
+        stderr, corr = cov_to_std(cov)
 
         var_par_i = 0
         for i, pname in enumerate(self.param_names):

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -749,11 +749,14 @@ class LogLikelihood:
 
         params = {**bestfit, **fix}
         if inverse_hessian is None:
-            inverse_hessian = self.inverse_hessian(
+            # inverse_hessian returns inverse of hessian of -2 loglikelihood
+            # but covariance matrix is inverse of hessian of - logikelihood
+            # (kA)^(-1) = k^(-1)A^(-1) for non-zero scalar k
+            inverse_hessian = 2. * self.inverse_hessian(
                 params,
                 omit_grads=tuple(fix.keys()))
 
-        stderr, cov = cov_to_std(inverse_hessian)
+        stderr, corr = cov_to_std(inverse_hessian)
 
         var_par_i = 0
         for i, pname in enumerate(self.param_names):
@@ -771,7 +774,7 @@ class LogLikelihood:
 
         var_pars = [x for x in self.param_names if x not in fix]
         df = pd.DataFrame(
-            {p1: {p2: cov[i1, i2]
+            {p1: {p2: corr[i1, i2]
                   for i2, p2 in enumerate(var_pars)}
              for i1, p1 in enumerate(var_pars)},
             columns=var_pars)


### PR DESCRIPTION
This PR fixes a bug in the computation of the covariance matrix used in `LogLikelihood.summary` and the computing a starting guess for the interval computation.

Mathematically, the estimator of the asymptotic covariance matrix is the inverse of the Fisher information matrix evaluated at the bestfit parameters of the fit. See [stack exchange article here](https://stats.stackexchange.com/questions/68080/basic-question-about-fisher-information-matrix-and-relationship-to-hessian-and-s) (or pg 101-102 of Statistical Methods in Experimental Physics 2nd Edition by Fred James).

`LogLikelihood.inverse_hessian` returns the inverse of the hessian of -2 loglikelihood, whereas the covariance is the inverse of the hessian of -loglikelihood.

The implementation of `LogLikelihood.inverse_hessian` is kept unchanged because conceptually, the object being minimised is indeed the -2 loglikelihood, and for cleanliness of the code `LogLikelihood.inverse_hessian` should return the inverse hessian of the object being minimised, which is the -2 loglikelihood.

The correct inverse hessian (inverse hessian of the -loglikelihood) is then passed into `cov_to_std`. The keyword argument `inverse_hessian` of `LogLikelihood.summary` is also changed to `cov` for clarity (that this is the inverse hessian of the -loglikelihood and not the inverse hessian of the -2 loglikelihood).

The following code snippet from @JelleAalbers is used to test the changes in the PR.
```
import numpy as np
import pandas as pd

import flamedisx as fd

class MySource(fd.ColumnSource):
    column = 'constant_diff_rate'
    mu = 1

n_obs = 10_000
data = pd.DataFrame(dict(constant_diff_rate=np.ones(n_obs)))

ll = fd.LogLikelihood(
    sources=dict(source=MySource), 
    data=data,
    batch_size=10_000,
    free_rates='source')

# This should be close to n_obs
bf = ll.bestfit(guess=dict(source_rate_multiplier=1.))
print(bf['source_rate_multiplier'], n_obs)

inv_hess = ll.inverse_hessian(bf)

ll.summary(
    bf, 
)
```

A source with constant diff rate and 10k observed events should give a 1 sigma error of +- 100. 

Using the current `main` branch (97d3862c0691e1f8e07efc220dea3cf03c646f3c), the computed 1 sigma error is incorrect (see screenshot below)
![wrong_std](https://user-images.githubusercontent.com/46324102/134973509-7a0cc313-2d27-475f-bc7b-a38b3aafac43.png)

Using this `fix_hessian_bug` branch(5a32d66bd987f13c789d8f27e655a5dbbab1087c), the computed 1 sigma error is as expected (see screenshot below
![correct_std](https://user-images.githubusercontent.com/46324102/134973682-6c1c7369-6bfe-46ce-bbee-ddfacfd41a78.png)
)
