### PR TITLE
Simplified p_electron and less params for the wall

### DIFF
--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -82,7 +82,7 @@ class DetectPhotonsOrElectrons(fd.Block):
         if self.check_efficiencies and np.any(eff <= 0):
             raise ValueError(f"Found event with nonpositive {self.quanta_name} "
                              "detection efficiency: did you apply and "
-                             "configure your cuts caorrectly?")
+                             "configure your cuts correctly?")
 
         # Estimate produced quanta
         n_prod_mle = d[self.quanta_name + 's_produced_mle'] = \

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -144,8 +144,8 @@ class DetectElectrons(DetectPhotonsOrElectrons):
         return extraction_eff * tf.exp(-drift_time / elife)
 
     @staticmethod
-    def electron_loss(pel):
-        return 1. + 0. * pel
+    def electron_loss(nel):
+        return 1. + 0. * nel
 
     electron_acceptance = 1.
 

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -139,11 +139,13 @@ class DetectElectrons(DetectPhotonsOrElectrons):
     @staticmethod
     def electron_detection_eff(drift_time, *,
                                elife=452e3):
+        # TODO: change the function name, it is a drift_efficiency
         return 1. * tf.exp(-drift_time / elife)
 
     @staticmethod
-    def extraction_eff(nel):
-        return 0.96 + 0. * nel
+    def extraction_eff(nel, *,
+                       mean_ext=0.96):
+        return mean_ext + 0. * nel
 
     electron_acceptance = 1.
 

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -41,7 +41,7 @@ class DetectPhotonsOrElectrons(fd.Block):
             p = p * self.gimme('electron_loss',
                                bonus_arg=quanta_produced,
                                data_tensor=data_tensor, ptensor=ptensor)
-    
+
         result = tfp.distributions.Binomial(
                 total_count=quanta_produced,
                 probs=tf.cast(p, dtype=fd.float_type())
@@ -146,7 +146,6 @@ class DetectElectrons(DetectPhotonsOrElectrons):
     @staticmethod
     def electron_loss(pel):
         return 1. + 0. * pel
-
 
     electron_acceptance = 1.
 

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -145,6 +145,7 @@ class DetectElectrons(DetectPhotonsOrElectrons):
 
     @staticmethod
     def electron_loss(nel):
+        # The function should output values between [0,1]
         return 1. + 0. * nel
 
     electron_acceptance = 1.

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -97,7 +97,7 @@ class MakeERQuanta(fd.Block):
     def _annotate(self, d):
         d['quanta_produced_noStep_min'] = (
                 d['electrons_produced_min']
-                + d['photons_produced_min'])
+                + d['photons_produced_min']).clip(1, None)
         annotate_ces(self, d)
 
     def _domain_dict_bonus(self, d):
@@ -236,7 +236,7 @@ def annotate_ces(self, d):
     for bound in ('min', 'max'):
         d['quanta_produced_' + bound] = (
                 d['electrons_produced_' + bound]
-                + d['photons_produced_' + bound])
+                + d['photons_produced_' + bound]).clip(1, None)
 
 
 def domain_dict_bonus(self, d):

--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -212,7 +212,7 @@ class MakeNRQuanta(fd.Block):
     def _annotate(self, d):
         d['quanta_produced_noStep_min'] = (
                 d['electrons_produced_min']
-                + d['photons_produced_min'])
+                + d['photons_produced_min']).clip(1, None)
         annotate_ces(self, d)
 
     def _domain_dict_bonus(self, d):

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -305,10 +305,16 @@ class SR1Source:
         # 0 * light yield is to fix the shape
         return single_electron_width + 0. * s2_relative_ly
 
+    @staticmethod
+    def double_pe_fraction(z, *, dpe=DEFAULT_P_DPE):
+        # Ties the double_pe_fraction model function to the dpe
+        # parameter in the sources
+        return dpe + 0 * z
+
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
-    def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1):
-        mean_eff= g1 / (1. + DEFAULT_P_DPE)
+    def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
+        mean_eff= g1 / (1. + dpe)
         return mean_eff * s1_relative_ly
 
     def photon_acceptance(self,
@@ -362,15 +368,15 @@ class SR1Source:
 class SR1ERSource(SR1Source, fd.ERSource):
 
     @staticmethod
-    def p_electron(nq, *, W=13.8e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
-                   gamma_er=0.031 , omega_er=31.):
+    def p_electron(nq, *, W=13.7e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
+                   gamma_er=0.031 , omega_er=31., delta_er=0.24):
         # gamma_er from paper 0.124/4
         F = tf.constant(DEFAULT_DRIFT_FIELD, dtype=fd.float_type())
 
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-0.24)
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-1.*delta_er)
 
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant
@@ -380,7 +386,7 @@ class SR1ERSource(SR1Source, fd.ERSource):
         return fd.safe_p(p_el)
 
     @staticmethod
-    def p_electron_fluctuation(nq, q2=0.034, q3_nq=123.):
+    def p_electron_fluctuation(nq, q2=0.034, q3_nq=124.):
         # From SR0, BBF model, right?
         # q3 = 1.7 keV ~= 123 quanta
         # For SR1:

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -459,7 +459,7 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
                                  elife,
                                  *,
                                  w_extraction_eff=0.89):
-         return w_extraction_eff * tf.exp(-drift_time / elife)
+          return w_extraction_eff * tf.exp(-drift_time / elife)
 
       @staticmethod
       def electron_loss(electrons_produced,
@@ -473,7 +473,7 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
       def electron_gain_mean(r,
                              *,
                              w_g2=25.5):
-         return g2 * tf.ones_like(r)
+          return g2 * tf.ones_like(r)
 
       @staticmethod
       def electron_gain_std(r,
@@ -481,21 +481,24 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
                             w_g2=25.5,
                             w_extraction_eff=0.89):
           # 0 * r is to fix the shape
-         single_electron_width=w_g2/w_extraction_eff*0.25
-         return single_electron_width + 0. * tf.ones_like(r)
+          single_electron_width=w_g2/w_extraction_eff*0.25
+          return single_electron_width + 0. * tf.ones_like(r)
 
       @staticmethod
-      def p_electron_fluctuation(nq, w_q2 = 0.0978, w_q3_nq = 145.): 
-         return tf.clip_by_value(
-                w_q2 * (tf.constant(1., dtype=fd.float_type()) - \
-                tf.exp(-nq / w_q3_nq)),
-                tf.constant(1e-4, dtype=fd.float_type()),
-                float('inf'))
+      def p_electron_fluctuation(nq, w_q2 = 0.0978, w_q3_nq = 145.):
+          return tf.clip_by_value(
+                 w_q2 * (tf.constant(1., dtype=fd.float_type()) - \
+                 tf.exp(-nq / w_q3_nq)),
+                 tf.constant(1e-4, dtype=fd.float_type()),
+                 float('inf'))
 
       # It is preferred to have higher energy spectrum for the wall
       energies = tf.cast(tf.linspace(0., 80. , 2000),
-                       dtype=fd.float_type())
-
+                         dtype=fd.float_type())
+      #exponentially falling energy spectrum to simulate beta spectrum
+      rates_vs_energy=tf.cast(0.9*tf.exp(-0.5*tf.linspace(0.,80.,2000))+0.1,
+                              dtype=fd.float_type())
+        
 @export
 class SR1WIMPSource(SR1NRSource, fd.WIMPSource):
     pass

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -449,7 +449,7 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
           Exponentially falling yield.
           """
           # TODO: Maybe this can be tied to W in a combined fit
-          W = 13.8e-3 #keV
+          W = 13.7e-3 #keV
           eps = (nq*W)
           qy = w_er_pel_c*tf.exp(-lam*eps)
           return fd.clip_by_value(qy * W, 1e-8, 1. - 1e-9)
@@ -467,7 +467,8 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
                         l_max=0.084,
                         alpha=0.0001,
                         l_min=0.002):
-          return l_max*(tf.exp(-alpha*electrons_produced))+l_min
+          return tf.clip_by_value(l_max*(tf.exp(-alpha*electrons_produced))+l_min,
+                                  1e-9, 1. - 1e-9)
 
       @staticmethod
       def electron_gain_mean(r,
@@ -482,7 +483,7 @@ class SR1WallSource(fd.SpatialRateERSource, SR1ERSource):
                             w_extraction_eff=0.89):
           # 0 * r is to fix the shape
           single_electron_width=w_g2/w_extraction_eff*0.25
-          return single_electron_width + 0. * tf.ones_like(r)
+          return single_electron_width + 0. * r
 
       @staticmethod
       def p_electron_fluctuation(nq, w_q2 = 0.0978, w_q3_nq = 145.):

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -286,10 +286,11 @@ class SR1Source:
                 * np.exp(d['drift_time'] / d['elife']))
     
     @staticmethod
-    def extraction_eff(electrons_produced,
-                       *,
-                       mean_ext=DEFAULT_EXTRACTION_EFFICIENCY):
-        return mean_ext + (0. * electrons_produced)
+    def electron_detection_eff(drift_time,
+                               elife,
+                               *,
+                               extraction_eff=DEFAULT_EXTRACTION_EFFICIENCY):
+        return extraction_eff * tf.exp(-drift_time / elife)
 
     @staticmethod
     def electron_gain_mean(s2_relative_ly,

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -309,9 +309,8 @@ class SR1Source:
     def double_pe_fraction(z, *, dpe=DEFAULT_P_DPE):
         # Ties the double_pe_fraction model function to the dpe
         # parameter in the sources
-        return dpe + 0 * z
+        return dpe + 0. * z
 
-    #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
     def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
         mean_eff = g1 / (1. + dpe)
@@ -376,7 +375,7 @@ class SR1ERSource(SR1Source, fd.ERSource):
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-1.*delta_er)
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-delta_er)
 
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -284,14 +284,12 @@ class SR1Source:
                 d['s2']
                 / d['s2_relative_ly']
                 * np.exp(d['drift_time'] / d['elife']))
-
-
+    
     @staticmethod
-    def electron_detection_eff(drift_time,
-                               elife,
-                               *,
-                               extraction_eff=DEFAULT_EXTRACTION_EFFICIENCY):
-        return extraction_eff * tf.exp(-drift_time / elife)
+    def extraction_eff(electrons_produced,
+                       *,
+                       mean_ext=DEFAULT_EXTRACTION_EFFICIENCY):
+        return mean_ext + (0. * electrons_produced)
 
     @staticmethod
     def electron_gain_mean(s2_relative_ly,

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -314,7 +314,7 @@ class SR1Source:
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
     def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
-        mean_eff= g1 / (1. + dpe)
+        mean_eff = g1 / (1. + dpe)
         return mean_eff * s1_relative_ly
 
     def photon_acceptance(self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.1
+numpy==1.22.2
 scipy==1.7.3
 pandas==1.4.0
 multihist==0.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ multihist==0.6.5
 wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.8.0
-tensorflow_probability==0.15.0
+tensorflow_probability==0.16.0
 iminuit==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.22.2
 scipy==1.7.3
-pandas==1.4.0
+pandas==1.4.1
 multihist==0.6.5
 wimprates==0.3.2
 tqdm==4.62.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.22.1
 scipy==1.7.3
 pandas==1.4.0
-multihist==0.6.4
+multihist==0.6.5
 wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy==1.8.0
 pandas==1.4.1
 multihist==0.6.5
 wimprates==0.3.2
-tqdm==4.62.3
+tqdm==4.63.0
 tensorflow==2.8.0
 tensorflow_probability==0.16.0
 iminuit==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.4
+numpy==1.21.5
 scipy==1.7.3
 pandas==1.3.5
 multihist==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.5
+numpy==1.21.4
 scipy==1.7.1
 pandas==1.3.4
 multihist==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.2
+numpy==1.22.3
 scipy==1.8.0
 pandas==1.4.1
 multihist==0.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.21.4
-scipy==1.7.2
+scipy==1.7.3
 pandas==1.3.4
 multihist==0.6.4
 wimprates==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.21.4
-scipy==1.7.1
+scipy==1.7.2
 pandas==1.3.4
 multihist==0.6.4
 wimprates==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.19.5
 scipy==1.7.1
-pandas==1.3.3
+pandas==1.3.4
 multihist==0.6.4
 wimprates==0.3.2
 tqdm==4.62.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.8.0
 tensorflow_probability==0.16.0
-iminuit==2.9.0
+iminuit==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.21.4
 scipy==1.7.3
-pandas==1.3.4
+pandas==1.3.5
 multihist==0.6.4
 wimprates==0.3.2
 tqdm==4.62.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.22.2
-scipy==1.7.3
+scipy==1.8.0
 pandas==1.4.1
 multihist==0.6.5
 wimprates==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.0
+numpy==1.22.1
 scipy==1.7.3
 pandas==1.3.5
 multihist==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ multihist==0.6.4
 wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.7.0
-tensorflow_probability==0.14.1
+tensorflow_probability==0.15.0
 iminuit==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.7.0
 tensorflow_probability==0.15.0
-iminuit==2.8.4
+iminuit==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pandas==1.4.0
 multihist==0.6.5
 wimprates==0.3.2
 tqdm==4.62.3
-tensorflow==2.7.0
+tensorflow==2.8.0
 tensorflow_probability==0.15.0
 iminuit==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pandas==1.3.4
 multihist==0.6.4
 wimprates==0.3.2
 tqdm==4.62.3
-tensorflow==2.6.0
+tensorflow==2.7.0
 tensorflow_probability==0.14.1
 iminuit==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.5
+numpy==1.22.0
 scipy==1.7.3
 pandas==1.3.5
 multihist==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.3.2
 tqdm==4.62.3
 tensorflow==2.6.0
 tensorflow_probability==0.14.1
-iminuit==2.8.3
+iminuit==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.22.1
 scipy==1.7.3
-pandas==1.3.5
+pandas==1.4.0
 multihist==0.6.4
 wimprates==0.3.2
 tqdm==4.62.3

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -297,9 +297,8 @@ def test_hessian_rateonly(xes: fd.ERSource):
         """
         @staticmethod
         def electron_detection_eff(drift_time, *,
-                                   different_elife=333e3,
-                                   extraction_eff=0.96):
-            return extraction_eff * tf.exp(-drift_time / different_elife)
+                                   different_elife=333e3):
+            return 1. * tf.exp(-drift_time / different_elife)
 
     # Test the hessian at the guess position
     lf = fd.LogLikelihood(

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -297,8 +297,9 @@ def test_hessian_rateonly(xes: fd.ERSource):
         """
         @staticmethod
         def electron_detection_eff(drift_time, *,
-                                   different_elife=333e3):
-            return 1. * tf.exp(-drift_time / different_elife)
+                                   different_elife=333e3,
+                                   extraction_eff=0.96):
+            return extraction_eff * tf.exp(-drift_time / different_elife)
 
     # Test the hessian at the guess position
     lf = fd.LogLikelihood(


### PR DESCRIPTION
This pull request makes the wall source simpler:
`p_electron` has now only one parameter and it is modelled as constant.
`electron_gain_mean` and `electron_gain_std` depends on `w_g2_total`, a fittable parameter, and `w_extraction_eff`

The variation of the parameters `w_q2`, `w_g2_total` and `w_er_pel_c` are enough to account for most of the possible wall event distributions in S1-S2. 

One possible further simplification would be to make also the `p_electron_fluctuation` just a single parameter. 