### PR TITLE
Clip bounds on quanta_produced to 1

### DIFF
--- a/flamedisx/lxe_blocks/quanta_generation.py
+++ b/flamedisx/lxe_blocks/quanta_generation.py
@@ -212,7 +212,7 @@ class MakeNRQuanta(fd.Block):
     def _annotate(self, d):
         d['quanta_produced_noStep_min'] = (
                 d['electrons_produced_min']
-                + d['photons_produced_min'])
+                + d['photons_produced_min']).clip(1, None)
         annotate_ces(self, d)
 
     def _domain_dict_bonus(self, d):


### PR DESCRIPTION
This fix avoids calculating the useless case of produced_quanta = 0 in `MakeERQuanta` / `MakeNRQuanta`. 

Perhaps because it always has probability 0, this case causes NaN gradient errors for some parameters (if max_sigma is high enough that `produced_quanta_min` hits 0 for some events). That observation is based on checking the per-batch gradients from `_log_likelihood` with a batch size of 1 and max_sigma 6 in a fitting notebook that @plt109 is using. After this fix the NaN gradients disappear and the fit runs normally (though slowly of course, due to the high max_sigma).

#127 introduced two essentially duplicated instances of the calculation this PR modifies, hence the triple modification here. Since #127 still has some pending comments anyway, I'll just add a remark there that we can get to on a bigger refactor, probably once Robert reaches the bottom of his stack of uncommitted NEST work.

@robertsjames this fix may be relevant to you as well, since there is similar code in the NEST sources. I did not touch these as I think you're working on this part. Fully general Bayes bounds would make this fix unnecessary, since the produced_quanta = 0 case should never have posterior probability (even in some hypothetical analysis in which both S1 and S2 are optional).
