### PR TITLE
Extraction efficiency detached

### DIFF
--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -297,9 +297,8 @@ def test_hessian_rateonly(xes: fd.ERSource):
         """
         @staticmethod
         def electron_detection_eff(drift_time, *,
-                                   different_elife=333e3,
-                                   extraction_eff=0.96):
-            return extraction_eff * tf.exp(-drift_time / different_elife)
+                                   different_elife=333e3):
+            return 1. * tf.exp(-drift_time / different_elife)
 
     # Test the hessian at the guess position
     lf = fd.LogLikelihood(


### PR DESCRIPTION
This PR detaches the extraction efficiency from the electron detection efficiency in a similar fashion to the `penning_quenching` in the S1 branch of the detection block. 
This modification allows the `extraction_eff` to be a model function that can be non uniform throughout the detector and possibly become also a function of the number of `electrons_produced`. This allows for more flexible modelling of sources that have some special distribution of S2 (wall), or for non optimal detector conditions where the extraction efficiency is non uniform and depends on the number of produced electrons. 

The core functionality of FLAMEDISX is not impacted by this change and none of the base computation are broken and all the sources that do not use explicitly `extraction_eff` as a parameter are not affected. **Config files might need to change**.
This change breaks any source that uses `extraction_eff` as a parameter and not as a model function. Specifically it breaks the Xe1T sources. A very easy fix to those sources will be provided in the next PR.