### PR TITLE
Tie dpe

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -305,10 +305,16 @@ class SR1Source:
         # 0 * light yield is to fix the shape
         return single_electron_width + 0. * s2_relative_ly
 
+    @staticmethod
+    def double_pe_fraction(z, *, dpe=DEFAULT_P_DPE):
+        # Ties the double_pe_fraction model function to the dpe
+        # parameter in the sources
+        return dpe + 0 * z
+
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
-    def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1):
-        mean_eff= g1 / (1. + DEFAULT_P_DPE)
+    def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
+        mean_eff= g1 / (1. + dpe)
         return mean_eff * s1_relative_ly
 
     def photon_acceptance(self,
@@ -362,15 +368,15 @@ class SR1Source:
 class SR1ERSource(SR1Source, fd.ERSource):
 
     @staticmethod
-    def p_electron(nq, *, W=13.8e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
-                   gamma_er=0.031 , omega_er=31.):
+    def p_electron(nq, *, W=13.7e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
+                   gamma_er=0.031 , omega_er=31., delta_er=0.24):
         # gamma_er from paper 0.124/4
         F = tf.constant(DEFAULT_DRIFT_FIELD, dtype=fd.float_type())
 
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-0.24)
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-1.*delta_er)
 
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant
@@ -380,7 +386,7 @@ class SR1ERSource(SR1Source, fd.ERSource):
         return fd.safe_p(p_el)
 
     @staticmethod
-    def p_electron_fluctuation(nq, q2=0.034, q3_nq=123.):
+    def p_electron_fluctuation(nq, q2=0.034, q3_nq=124.):
         # From SR0, BBF model, right?
         # q3 = 1.7 keV ~= 123 quanta
         # For SR1:

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -309,9 +309,8 @@ class SR1Source:
     def double_pe_fraction(z, *, dpe=DEFAULT_P_DPE):
         # Ties the double_pe_fraction model function to the dpe
         # parameter in the sources
-        return dpe + 0 * z
+        return dpe + 0. * z
 
-    #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
     def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
         mean_eff = g1 / (1. + dpe)
@@ -376,7 +375,7 @@ class SR1ERSource(SR1Source, fd.ERSource):
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-1.*delta_er)
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-delta_er)
 
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -314,7 +314,7 @@ class SR1Source:
     #TODO: implement better the double_pe_fraction or photon_detection_efficiency as parameter
     @staticmethod
     def photon_detection_eff(s1_relative_ly, g1=DEFAULT_G1, dpe=DEFAULT_P_DPE):
-        mean_eff= g1 / (1. + dpe)
+        mean_eff = g1 / (1. + dpe)
         return mean_eff * s1_relative_ly
 
     def photon_acceptance(self,


### PR DESCRIPTION
This pull request ties the model parameter `dpe` of class `SR1Source` with model function `double_pe_fraction` via the following
```
    @staticmethod
    def double_pe_fraction(z, *, dpe=DEFAULT_P_DPE):
        # Ties the double_pe_fraction model function to the dpe
        # parameter in the sources
        return dpe + 0 * z
```
The `0*z` is just to get the right tensor shape. Without this, the user would be varying `dpe` as a nuisance parameter but this value of the double photoelectron probability would not be propagated downwards to the model function `double_pe_fraction`.

`delta_er` was also made a float-able parameter in this PR, and the default value of `W` was changed to the literature value of 13.7 keV instead of the 1T BBF posterior value of 13.8 keV.

These changes were tested extensively in [commit c2cdc7ad](https://github.com/FlamTeam/flamedisx/commit/c2cdc7ad89cd3c10c17c2efcbf5cc57aaed805e9) but it is easier to add the changes in from a fresh branch after the changes merged in from [PR 193](https://github.com/FlamTeam/flamedisx/pull/193). The same tests are currently being performed on this commit, will update PR with plots once results are out.