### PR TITLE
Add field to config

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -422,7 +422,12 @@ class SR1NRSource(SR1Source, fd.NRSource):
         """
         # TODO: so to make field pos-dependent, override this entire f?
         # could be made easier...
-        #drift_field = tf.constant(self.default_drift_field, dtype=fd.float_type())
+
+        # in _compute, n_events = batch_size
+        # drift_field is originally a (n_events) tensor, nq a (n_events, n_nq) tensor
+        # Insert empty axis in drift_field for broadcasting for tf to broadcast over nq dimension
+        if tf.is_tensor(nq):
+            drift_field = drift_field[:, None]
 
         # prevent /0  # TODO can do better than this
         nq = nq + 1e-9

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -157,6 +157,7 @@ def construct_exponential_r_spatial_hist(n = 2e6, max_r = 42.8387,
 class SR1Source:
     drift_velocity = DEFAULT_DRIFT_VELOCITY
     default_elife = DEFAULT_ELECTRON_LIFETIME
+    default_drift_field = DEFAULT_DRIFT_FIELD
 
     model_attributes = ('path_cut_accept_s1',
                         'path_cut_accept_s2',
@@ -168,6 +169,7 @@ class SR1Source:
                         'variable_elife',
                         'default_elife',
                         'path_electron_lifetimes',
+                        'default_drift_field',
                         )
 
     # Light yield maps

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -372,7 +372,7 @@ class SR1ERSource(SR1Source, fd.ERSource):
     def p_electron(nq, *, W=13.7e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
                    gamma_er=0.031 , omega_er=31., delta_er=0.24):
         # gamma_er from paper 0.124/4
-        F = tf.constant(DEFAULT_DRIFT_FIELD, dtype=fd.float_type())
+        F = tf.constant(self.default_drift_field, dtype=fd.float_type())
 
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
@@ -404,8 +404,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
 
     def p_electron(self, nq, *,
                    alpha=1.280, zeta=0.045, beta=273 * .9e-4,
-                   gamma=0.0141, delta=0.062,
-                   drift_field=DEFAULT_DRIFT_FIELD):
+                   gamma=0.0141, delta=0.062):
         """Fraction of detectable NR quanta that become electrons,
         slightly adjusted from Lenardo et al.'s global fit
         (https://arxiv.org/abs/1412.4417).
@@ -414,6 +413,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
         """
         # TODO: so to make field pos-dependent, override this entire f?
         # could be made easier...
+        drift_field = tf.constant(self.default_drift_field, dtype=fd.float_type())
 
         # prevent /0  # TODO can do better than this
         nq = nq + 1e-9

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -276,6 +276,8 @@ class SR1Source:
             else:
                 d['elife'] = self.default_elife
 
+        d['drift_field'] = self.default_drift_field
+
         # Add cS1 and cS2 following XENON conventions.
         # Skip this if s1/s2 are not known, since we're simulating
         # TODO: This is a kludge...
@@ -369,15 +371,22 @@ class SR1Source:
 class SR1ERSource(SR1Source, fd.ERSource):
 
     @staticmethod
-    def p_electron(nq, *, W=13.7e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
+    def p_electron(nq, drift_field, *, W=13.7e-3, mean_nexni=0.15,  q0=1.13, q1=0.47,
                    gamma_er=0.031 , omega_er=31., delta_er=0.24):
         # gamma_er from paper 0.124/4
-        F = tf.constant(self.default_drift_field, dtype=fd.float_type())
+        #F = tf.constant(self.default_drift_field, dtype=fd.float_type())
+
+        if tf.is_tensor(nq):
+            # in _compute, n_events = batch_size
+            # drift_field is originally a (n_events) tensor, nq a (n_events, n_nq) tensor
+            # Insert empty axis in drift_field for broadcasting for tf to broadcast over nq dimension
+
+            drift_field = drift_field[:, None]
 
         e_kev = nq * W
         fi = 1. / (1. + mean_nexni)
         ni, nex = nq * fi, nq * (1. - fi)
-        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * F ** (-delta_er)
+        wiggle_er = gamma_er * tf.exp(-e_kev / omega_er) * drift_field ** (-delta_er)
 
         # delta_er and gamma_er are highly correlated
         # F **(-delta_er) set to constant
@@ -402,7 +411,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
     # TODO: Define the proper nr spectrum
     # TODO: Modify the SR1NRSource to fit AmBe data better
 
-    def p_electron(self, nq, *,
+    def p_electron(self, nq, drift_field, *,
                    alpha=1.280, zeta=0.045, beta=273 * .9e-4,
                    gamma=0.0141, delta=0.062):
         """Fraction of detectable NR quanta that become electrons,
@@ -413,7 +422,7 @@ class SR1NRSource(SR1Source, fd.NRSource):
         """
         # TODO: so to make field pos-dependent, override this entire f?
         # could be made easier...
-        drift_field = tf.constant(self.default_drift_field, dtype=fd.float_type())
+        #drift_field = tf.constant(self.default_drift_field, dtype=fd.float_type())
 
         # prevent /0  # TODO can do better than this
         nq = nq + 1e-9


### PR DESCRIPTION
The default drift field is made a model attribute so that it can be set via a configuration file instead of changing the value of `DEFAULT_DRIFT_FIELD` in `x1t_sr1.py`. This is useful to adapt the current drift field value which was set to the field value of xenon1T SR1 to the nominal drift field value in xenonnT. Note that the drift field is still a single value throughout the entire TPC (drift field is not a function of position).

The changes in this PR affect both `fd.SR1ERSource` and `fd.SR1NRSource` via `p_electron` in each of these sources. To ensure that the changes do not induce any bugs in the fitting process, MC events were simulated and fitted for both `fd.SR1ERSource` and `fd.SR1NRSource`.

For `fd.SR1ERSource`, the optimizer converged as expected (the biases are still there, but this is a known feature) when floating the full set of ER model parameters.
![Screenshot from 2022-03-28 17-06-05](https://user-images.githubusercontent.com/46324102/160429182-f88ebcc6-be32-4b14-b950-a48420dcc7e7.png)

For `fd.SR1NRSource`, the optimizer converged as expected (the biases are still there, but this is a known feature) when floating the NR model parameters except Lindhard K, which @Ashley-Joy does not intend to float from his other studies.
![Screenshot from 2022-03-28 17-06-14](https://user-images.githubusercontent.com/46324102/160429496-ce3a1dc8-b047-401b-a81b-f23283690171.png)

Testing notebook available upon request.