### PR TITLE
add s2 aft into model attributes configurable via config files

### DIFF
--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -155,10 +155,6 @@ def construct_exponential_r_spatial_hist(n = 2e6, max_r = 42.8387,
 # Flamedisx sources
 ##
 class SR1Source:
-    drift_velocity = DEFAULT_DRIFT_VELOCITY
-    default_elife = DEFAULT_ELECTRON_LIFETIME
-    default_drift_field = DEFAULT_DRIFT_FIELD
-
     model_attributes = ('path_cut_accept_s1',
                         'path_cut_accept_s2',
                         'path_s1_rly',
@@ -170,7 +166,13 @@ class SR1Source:
                         'default_elife',
                         'path_electron_lifetimes',
                         'default_drift_field',
+                        's2_area_fraction_top',
                         )
+
+    drift_velocity = DEFAULT_DRIFT_VELOCITY
+    default_elife = DEFAULT_ELECTRON_LIFETIME
+    default_drift_field = DEFAULT_DRIFT_FIELD
+    s2_area_fraction_top = DEFAULT_AREA_FRACTION_TOP
 
     # Light yield maps
     path_s1_rly = '1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json'
@@ -353,7 +355,8 @@ class SR1Source:
                       # Needed for future sources i.e. wall
                       cs2b_min=50.1,
                       cs2b_max=7940.):
-        cs2b = cs2*(1-DEFAULT_AREA_FRACTION_TOP)
+        cs2b = cs2*(1-self.s2_area_fraction_top)
+        
         acceptance = tf.where((cs2b > cs2b_min) & (cs2b < cs2b_max) 
                                                 & (s2 > s2_min),
                               tf.ones_like(s2, dtype=fd.float_type()),


### PR DESCRIPTION
[PR 217](https://github.com/FlamTeam/flamedisx/pull/217) has a messy commit history so I created another branch with the same changes but from a repo without a messy commit history, and tested the changes again.

The default s2 area fraction top is made a model attribute, `s2_area_fraction_top`, so that it can be set via a configuration file instead of changing the value of `DEFAULT_AREA_FRACTION_TOP` in `x1t_sr1.py`. It is also explicitly called `s2_area_fraction_top` to differentiate it from `s1_area_fraction_top` which is used in other cuts currently not explicitly used in flamedisx.

This is useful to change the s2 area fraction top value which is used to compute the cs2b values in `s2_acceptance` and apply the cuts on cs2b.

The changes in this PR affect both `fd.SR1ERSource`, `fd.SR1NRSource`, `fd.SR1WallSource` via `s2_acceptance` from the base class `SR1ERSource`. To ensure that the changes do not induce any bugs in the fitting process, MC events were simulated and fitted for both `fd.SR1ERSource` and `fd.SR1NRSource`.

For `fd.SR1ERSource`, the optimizer converged as expected (the biases are still there, but this is a known feature) when floating the full set of ER model parameters.

![Screenshot from 2022-04-14 13-37-59](https://user-images.githubusercontent.com/46324102/163383480-7f5fdeb8-0b8b-4b34-bc68-7da8d7f2d762.png)

For fd.SR1NRSource, the optimizer converged as expected (the biases are still there, but this is a known feature) when floating the NR mo
![Screenshot from 2022-04-14 13-35-26](https://user-images.githubusercontent.com/46324102/163383510-20a3c972-8b23-4983-b590-f1ff3defebe4.png)
del parameters except Lindhard K, which @Ashley-Joy does not intend to float from his other studies.

Testing notebook available upon request.