### PR TITLE
Add field map

### DIFF
--- a/.github/workflows/test_flamedisx.yml
+++ b/.github/workflows/test_flamedisx.yml
@@ -25,4 +25,4 @@ jobs:
         pytest
     - name: Lint with flake8
       run: |
-        flake8 --per-file-ignores="__init__.py:F401,F403" --max-line-length=120 --exclude "x1t_sr1.py, tfp_files" --count flamedisx
+        flake8 --per-file-ignores="__init__.py:F401,F403" --max-line-length=120 --exclude "x1t_sr1.py, tfp_files, itp_map.py" --count flamedisx

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -280,7 +280,7 @@ def load_config(config_files=None):
             if not k.startswith('_')})
 
     return config
-    
+
 
 # Taken from straxen to filter arguments for interpolators
 @export

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import subprocess
 
+import inspect
 import numpy as np
 import pandas as pd
 from scipy import stats

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -279,3 +279,17 @@ def load_config(config_files=None):
             if not k.startswith('_')})
 
     return config
+    
+
+# Taken from straxen to filter arguments for interpolators
+@export
+def filter_kwargs(func, kwargs):
+    """Filter out keyword arguments that
+        are not in the call signature of func
+        and return filtered kwargs dictionary
+    """
+    params = inspect.signature(func).parameters
+    if any([str(p).startswith('**') for p in params.values()]):
+        # if func accepts wildcard kwargs, return all
+        return kwargs
+    return {k: v for k, v in kwargs.items() if k in params}

--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -199,7 +199,7 @@ class InterpolatingMap:
         assert dimensions == 2, 'RectBivariateSpline interpolate maps of dimension 2'
         assert not array_valued, 'RectBivariateSpline does not support interpolating array values'
         map_data = map_data.reshape(*grid_shape)
-        kwargs = straxen.filter_kwargs(RectBivariateSpline, kwargs)
+        #kwargs = straxen.filter_kwargs(RectBivariateSpline, kwargs)
         rbs = RectBivariateSpline(grid[0], grid[1], map_data, **kwargs)
 
         def arg_formated_rbs(positions):
@@ -221,7 +221,7 @@ class InterpolatingMap:
             map_data = map_data.reshape(*grid_shape)
 
         config = dict(bounds_error=False, fill_value=None)
-        kwargs = straxen.filter_kwargs(RegularGridInterpolator, kwargs)
+        #kwargs = straxen.filter_kwargs(RegularGridInterpolator, kwargs)
         config.update(kwargs)
         
         return RegularGridInterpolator(tuple(grid), map_data, **config)
@@ -232,7 +232,7 @@ class InterpolatingMap:
             map_data = map_data.reshape((-1, map_data.shape[-1]))
         else:
             map_data = map_data.flatten()
-        kwargs = straxen.filter_kwargs(InterpolateAndExtrapolate, kwargs)
+        #kwargs = straxen.filter_kwargs(InterpolateAndExtrapolate, kwargs)
         return InterpolateAndExtrapolate(csys, map_data, array_valued=array_valued, **kwargs)
 
     def scale_coordinates(self, scaling_factor, map_name='map'):

--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -22,7 +22,8 @@ class InterpolateAndExtrapolate:
     weighted averaging between nearby points.
     """
 
-    def __init__(self, points, values, neighbours_to_use=None, array_valued=False):
+    def __init__(self, points, values,
+                 neighbours_to_use=None, array_valued=False):
         """
         :param points: array (n_points, n_dims) of coordinates
         :param values: array (n_points) of values
@@ -76,7 +77,8 @@ class InterpolatingMap:
     with the straightforward generalization to 1d and 3d.
 
     Alternatively, a grid coordinate system can be specified as follows:
-        'coordinate_system' :   [['x', [x_min, x_max, n_x]], [['y', [y_min, y_max, n_y]]
+    'coordinate_system' : [['x', [x_min, x_max, n_x]],
+                          [['y', [y_min, y_max, n_y]]
 
     Alternatively, an N-vector-valued map can be specified by an array with
     last dimension N in 'map'.
@@ -88,14 +90,15 @@ class InterpolatingMap:
         'map': 42,
         etc
 
-    Default method return inverse-distance weighted average of nearby 2 * dim points
-    Extra support includes RectBivariateSpline, RegularGridInterpolator in scipy
-    by pass keyword argument like
-        method='RectBivariateSpline'
+    Default method return inverse-distance weighted average of nearby
+    2 * dim points. Extra support includes RectBivariateSpline,
+    RegularGridInterpolator in scipy by pass keyword argument like
+    method='RectBivariateSpline'
 
     The interpolators are called with
-        'positions' :  [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...]
-        'map_name'  :  key to switch to map interpolator other than the default 'map'
+    'positions' :  [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...]
+    'map_name'  :  key to switch to map interpolator other than
+                   the default 'map'
     """
     metadata_field_names = ['timestamp', 'description', 'coordinate_system',
                             'name', 'irregular', 'compressed', 'quantized']
@@ -119,8 +122,8 @@ class InterpolatingMap:
 
             compressor, dtype, shape = self.data['compressed']
             self.data['map'] = np.frombuffer(
-                strax.io.COMPRESSORS[compressor]['decompress'](self.data['map']),
-                dtype=dtype).reshape(*shape)
+              strax.io.COMPRESSORS[compressor]['decompress'](self.data['map']),
+              dtype=dtype).reshape(*shape)
             del self.data['compressed']
         if 'quantized' in self.data:
             self.data['map'] = self.data['quantized'] * self.data['map'].astype(np.float32)
@@ -223,7 +226,7 @@ class InterpolatingMap:
         config = dict(bounds_error=False, fill_value=None)
         kwargs = fd.filter_kwargs(RegularGridInterpolator, kwargs)
         config.update(kwargs)
-        
+
         return RegularGridInterpolator(tuple(grid), map_data, **config)
 
     @staticmethod
@@ -237,7 +240,8 @@ class InterpolatingMap:
 
     def scale_coordinates(self, scaling_factor, map_name='map'):
         """Scales the coordinate system by the specified factor
-        :params scaling_factor: array (n_dim) of scaling factors if different or single scalar.
+        :params scaling_factor: array (n_dim) of scaling factors
+        if different or single scalar.
         """
         if self.dimensions == 0:
             return

--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -1,6 +1,7 @@
 """Code to load XENON-specific correction maps
 
 Adapted from https://github.com/XENONnT/straxen/blob/master/straxen/itp_map.py
+commit 156c5b1f0aad543ad5707911e2ee301a091a40a4
 """
 import logging
 import gzip
@@ -9,6 +10,7 @@ import re
 
 import numpy as np
 from scipy.spatial import cKDTree
+from scipy.interpolate import RectBivariateSpline, RegularGridInterpolator
 
 import flamedisx as fd
 export, __all__ = fd.exporter()
@@ -28,7 +30,7 @@ class InterpolateAndExtrapolate:
         averaging. Default is 2 * dimensions of points.
         """
         self.kdtree = cKDTree(points)
-        self.values = values.astype(np.float)
+        self.values = values
         if neighbours_to_use is None:
             neighbours_to_use = points.shape[1] * 2
         self.neighbours_to_use = neighbours_to_use
@@ -86,11 +88,19 @@ class InterpolatingMap:
         'map': 42,
         etc
 
-    """
-    data_field_names = ['timestamp', 'description', 'coordinate_system',
-                        'name', 'irregular']
+    Default method return inverse-distance weighted average of nearby 2 * dim points
+    Extra support includes RectBivariateSpline, RegularGridInterpolator in scipy
+    by pass keyword argument like
+        method='RectBivariateSpline'
 
-    def __init__(self, data):
+    The interpolators are called with
+        'positions' :  [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...]
+        'map_name'  :  key to switch to map interpolator other than the default 'map'
+    """
+    metadata_field_names = ['timestamp', 'description', 'coordinate_system',
+                            'name', 'irregular', 'compressed', 'quantized']
+
+    def __init__(self, data, method='WeightedNearestNeighbors', **kwargs):
         if isinstance(data, bytes):
             data = gzip.decompress(data).decode()
         if isinstance(data, (str, bytes)):
@@ -99,7 +109,7 @@ class InterpolatingMap:
         self.data = data
 
         # Decompress / dequantize the map
-        # TODO: support multiple map names
+        # We should support multiple map names!
         if 'compressed' in self.data:
             try:
                 import strax
@@ -116,51 +126,141 @@ class InterpolatingMap:
             self.data['map'] = self.data['quantized'] * self.data['map'].astype(np.float32)
             del self.data['quantized']
 
-        cs = self.data['coordinate_system']
-        if not cs:
+        csys = self.data['coordinate_system']
+        if not len(csys):
             self.dimensions = 0
-        elif isinstance(cs[0], list) and isinstance(cs[0][0], str):
+        elif isinstance(csys[0][0], str):
             # Support for specifying coordinate system as a gridspec
             grid = [np.linspace(left, right, points)
-                    for _, (left, right, points) in cs]
-            cs = np.array(np.meshgrid(*grid, indexing='ij'))
-            cs = np.transpose(cs, np.roll(np.arange(len(grid)+1), -1))
-            cs = np.array(cs).reshape((-1, len(grid)))
+                    for _, (left, right, points) in csys]
+            csys = np.array(np.meshgrid(*grid, indexing='ij'))
+            axes = np.roll(np.arange(len(grid) + 1), -1)
+            csys = np.transpose(csys, axes)
+            csys = np.array(csys).reshape((-1, len(grid)))
             self.dimensions = len(grid)
         else:
-            self.dimensions = len(cs[0])
+            csys = np.array(csys)
+            self.dimensions = len(csys[0])
 
-        self.coordinate_system = cs
+        self.coordinate_system = csys
         self.interpolators = {}
         self.map_names = sorted([k for k in self.data.keys()
-                                 if k not in self.data_field_names])
+                                 if k not in self.metadata_field_names])
 
         log = logging.getLogger('InterpolatingMap')
-        log.debug('Map name: %s' % self.data['name'])
+        log.debug('Map name: %s' % self.data.get('name',
+                                                 "NO NAME?!"))
         log.debug('Map description:\n    ' +
-                  re.sub(r'\n', r'\n    ', self.data['description']))
+                  re.sub(r'\n', r'\n    ', self.data.get('description',
+                                                         "NO DESCRIPTION?!")))
         log.debug("Map names found: %s" % self.map_names)
 
         for map_name in self.map_names:
-            map_data = np.array(self.data[map_name])
-            array_valued = len(map_data.shape) == self.dimensions + 1
+            # Specify dtype float to set Nones to nan
+            map_data = np.array(self.data[map_name], dtype=np.float64)
+            if len(self.coordinate_system) == len(map_data):
+                array_valued = len(map_data.shape) == 2
+            else:
+                array_valued = len(map_data.shape) == self.dimensions + 1
+
             if self.dimensions == 0:
                 # 0 D -- placeholder maps which take no arguments
                 # and always return a single value
-                def itp_fun(positions, _data=map_data):
-                    return np.array([_data])
+                def itp_fun(positions):
+                    return np.array([map_data])
+
+            elif method == 'RectBivariateSpline':
+                itp_fun = self._rect_bivariate_spline(csys, map_data, array_valued, **kwargs)
+
+            elif method == 'RegularGridInterpolator':
+                itp_fun = self._regular_grid_interpolator(csys, map_data, array_valued, **kwargs)
+
+            elif method == 'WeightedNearestNeighbors':
+                itp_fun = self._weighted_nearest_neighbors(csys, map_data, array_valued, **kwargs)
+
             else:
-                if array_valued:
-                    map_data = map_data.reshape((-1, map_data.shape[-1]))
-                itp_fun = InterpolateAndExtrapolate(points=np.array(cs),
-                                                    values=np.array(map_data),
-                                                    array_valued=array_valued)
+                raise ValueError(f'Interpolation method {method} is not supported')
 
             self.interpolators[map_name] = itp_fun
 
-    def __call__(self, positions, map_name='map'):
+    def __call__(self, *args, map_name='map'):
         """Returns the value of the map at the position given by coordinates
         :param positions: array (n_dim) or (n_points, n_dim) of positions
         :param map_name: Name of the map to use. Default is 'map'.
         """
-        return self.interpolators[map_name](positions)
+        return self.interpolators[map_name](*args)
+
+    @staticmethod
+    def _rect_bivariate_spline(csys, map_data, array_valued, **kwargs):
+        dimensions = len(csys[0])
+        grid = [np.unique(csys[:, i]) for i in range(dimensions)]
+        grid_shape = [len(g) for g in grid]
+
+        assert dimensions == 2, 'RectBivariateSpline interpolate maps of dimension 2'
+        assert not array_valued, 'RectBivariateSpline does not support interpolating array values'
+        map_data = map_data.reshape(*grid_shape)
+        kwargs = straxen.filter_kwargs(RectBivariateSpline, kwargs)
+        rbs = RectBivariateSpline(grid[0], grid[1], map_data, **kwargs)
+
+        def arg_formated_rbs(positions):
+            if isinstance(positions, list):
+                positions = np.array(positions)
+            return rbs.ev(positions[:, 0], positions[:, 1])
+
+        return arg_formated_rbs
+
+    @staticmethod
+    def _regular_grid_interpolator(csys, map_data, array_valued, **kwargs):
+        dimensions = len(csys[0])
+        grid = [np.unique(csys[:, i]) for i in range(dimensions)]
+        grid_shape = [len(g) for g in grid]
+
+        if array_valued:
+            map_data = map_data.reshape((*grid_shape, map_data.shape[-1]))
+        else:
+            map_data = map_data.reshape(*grid_shape)
+
+        config = dict(bounds_error=False, fill_value=None)
+        kwargs = straxen.filter_kwargs(RegularGridInterpolator, kwargs)
+        config.update(kwargs)
+        
+        return RegularGridInterpolator(tuple(grid), map_data, **config)
+
+    @staticmethod
+    def _weighted_nearest_neighbors(csys, map_data, array_valued, **kwargs):
+        if array_valued:
+            map_data = map_data.reshape((-1, map_data.shape[-1]))
+        else:
+            map_data = map_data.flatten()
+        kwargs = straxen.filter_kwargs(InterpolateAndExtrapolate, kwargs)
+        return InterpolateAndExtrapolate(csys, map_data, array_valued=array_valued, **kwargs)
+
+    def scale_coordinates(self, scaling_factor, map_name='map'):
+        """Scales the coordinate system by the specified factor
+        :params scaling_factor: array (n_dim) of scaling factors if different or single scalar.
+        """
+        if self.dimensions == 0:
+            return
+        if hasattr(scaling_factor, '__len__'):
+            assert (len(scaling_factor) == self.dimensions), \
+                f"Scaling factor array dimension {len(scaling_factor)} " \
+                f"does not match grid dimension {self.dimensions}"
+            self._sf = scaling_factor
+        if isinstance(scaling_factor, (int, float)):
+            self._sf = [scaling_factor] * self.dimensions
+
+        alt_csys = self.coordinate_system
+        for i, gp in enumerate(self.coordinate_system):
+            alt_csys[i] = [gc * k for (gc, k) in zip(gp, self._sf)]
+
+        map_data = np.array(self.data[map_name])
+        if len(self.coordinate_system) == len(map_data):
+            array_valued = len(map_data.shape) == 2
+        else:
+            array_valued = len(map_data.shape) == self.dimensions + 1
+        if array_valued:
+            map_data = map_data.reshape((-1, map_data.shape[-1]))
+        itp_fun = InterpolateAndExtrapolate(points=np.array(alt_csys),
+                                            values=np.array(map_data),
+                                            array_valued=array_valued)
+        self.interpolators[map_name] = itp_fun

--- a/flamedisx/xenon/itp_map.py
+++ b/flamedisx/xenon/itp_map.py
@@ -199,7 +199,7 @@ class InterpolatingMap:
         assert dimensions == 2, 'RectBivariateSpline interpolate maps of dimension 2'
         assert not array_valued, 'RectBivariateSpline does not support interpolating array values'
         map_data = map_data.reshape(*grid_shape)
-        #kwargs = straxen.filter_kwargs(RectBivariateSpline, kwargs)
+        kwargs = fd.filter_kwargs(RectBivariateSpline, kwargs)
         rbs = RectBivariateSpline(grid[0], grid[1], map_data, **kwargs)
 
         def arg_formated_rbs(positions):
@@ -221,7 +221,7 @@ class InterpolatingMap:
             map_data = map_data.reshape(*grid_shape)
 
         config = dict(bounds_error=False, fill_value=None)
-        #kwargs = straxen.filter_kwargs(RegularGridInterpolator, kwargs)
+        kwargs = fd.filter_kwargs(RegularGridInterpolator, kwargs)
         config.update(kwargs)
         
         return RegularGridInterpolator(tuple(grid), map_data, **config)
@@ -232,7 +232,7 @@ class InterpolatingMap:
             map_data = map_data.reshape((-1, map_data.shape[-1]))
         else:
             map_data = map_data.flatten()
-        #kwargs = straxen.filter_kwargs(InterpolateAndExtrapolate, kwargs)
+        kwargs = fd.filter_kwargs(InterpolateAndExtrapolate, kwargs)
         return InterpolateAndExtrapolate(csys, map_data, array_valued=array_valued, **kwargs)
 
     def scale_coordinates(self, scaling_factor, map_name='map'):

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -155,7 +155,8 @@ def construct_exponential_r_spatial_hist(n = 2e6, max_r = 42.8387,
 # Flamedisx sources
 ##
 class SR1Source:
-    model_attributes = ('path_cut_accept_s1',
+    model_attributes = ('s2_area_fraction_top',
+                        'path_cut_accept_s1',
                         'path_cut_accept_s2',
                         'path_s1_rly',
                         'path_s2_rly',
@@ -165,14 +166,17 @@ class SR1Source:
                         'variable_elife',
                         'default_elife',
                         'path_electron_lifetimes',
+                        'variable_drift_field',
                         'default_drift_field',
-                        's2_area_fraction_top',
+                        'path_drift_field',
+                        'path_drift_field_distortion',
+                        'path_drift_field_distortion_correction',
                         )
 
+    s2_area_fraction_top = DEFAULT_AREA_FRACTION_TOP
     drift_velocity = DEFAULT_DRIFT_VELOCITY
     default_elife = DEFAULT_ELECTRON_LIFETIME
     default_drift_field = DEFAULT_DRIFT_FIELD
-    s2_area_fraction_top = DEFAULT_AREA_FRACTION_TOP
 
     # Light yield maps
     path_s1_rly = '1t_maps/XENON1T_s1_xyz_ly_kr83m-SR1_pax-664_fdc-adcorrtpf.json'
@@ -199,6 +203,16 @@ class SR1Source:
     # Elife maps
     variable_elife = True
     path_electron_lifetimes = ('1t_maps/electron_lifetimes_sr1.json',)
+
+    # Comsol map
+    variable_drift_field = True
+    path_drift_field = 'nt_maps/fieldmap_2D_B2d75n_C2d75n_G0d3p_A4d9p_T0d9n_PMTs1d3n_FSR0d65p.json'
+
+    # Field distortion map
+    path_drift_field_distortion = 'nt_maps/init_to_final_position_mapping_B2d75n_C2d75n_G0d3p_A4d9p_T0d9n_PMTs1d3n_FSR0d65p.json'
+
+    # FDC map
+    path_drift_field_distortion_correction = 'nt_maps/XnT_3D_FDC_xyt_MLP_v0.2_B2d75n_C2d75n_G0d3p_A4d9p_T0d9n_PMTs1d3n_FSR0d65p.json'
 
     def set_defaults(self, *args, **kwargs):
         super().set_defaults(*args, **kwargs)

--- a/flamedisx/xenon/x1t_sr1.py
+++ b/flamedisx/xenon/x1t_sr1.py
@@ -205,7 +205,7 @@ class SR1Source:
     path_electron_lifetimes = ('1t_maps/electron_lifetimes_sr1.json',)
 
     # Comsol map
-    variable_drift_field = True
+    variable_drift_field = False
     path_drift_field = 'nt_maps/fieldmap_2D_B2d75n_C2d75n_G0d3p_A4d9p_T0d9n_PMTs1d3n_FSR0d65p.json'
 
     # Field distortion map


### PR DESCRIPTION
## Why?
The spatial variation of the drift field gets increasingly important as liquid xenon TPCs become larger. The ability to model such inhomogeneities in the drift field also opens up the possibility of extending the fiducial volume instead of trimming those regions away.

## What? How?
This pull request allows the user to incorporate a spatially dependent drift field into `SR1ERSource` and `SR1NRSource` which is interpolated from an external drift field map. The field distortion and field distortion correction are also included.

## Testing? Screenshots (optional)
The fit to ER MC events converges without any issue even though the bias is still there:
![Screenshot from 2022-05-09 00-30-58](https://user-images.githubusercontent.com/46324102/167319517-79bf3c17-1b52-4b36-b244-c1eedcf5e19a.png)
The fit to NR MC events converges without any issue even though the bias is still there:
![Screenshot from 2022-05-09 00-59-46](https://user-images.githubusercontent.com/46324102/167319530-57b8b177-76fc-477c-af34-394e71263061.png)
@Ashley-Joy, you might want to test this to make sure that the changes do not cause any breaking changes to your work. The drift field can be set to a single number(turn off spatial dependence of drift field) by setting `variable_drift_field = False` in the config file.