### PR TITLE
Mu estimation options, saving and loading

### DIFF
--- a/flamedisx/__init__.py
+++ b/flamedisx/__init__.py
@@ -6,6 +6,7 @@ from .block_source import *
 from .likelihood import *
 from .inference import *
 from .bounds import *
+from .mu_estimation import *
 
 # Original flamedisx models
 # Accessible under fd root package (for now), for backwards compatibility

--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -484,10 +484,10 @@ class BlockModelSource(fd.Source):
     def _simulate_response(self):
         # All blocks after the first help to simulate the response
         d = self.data
-        d['p_accepted'] = 1.
+        d['p_accepted'] = 1.   # Cut on p_accepted is made in Source.simulate
         for b in self.model_blocks[1:]:
             b.simulate(d)
-        return d.iloc[np.random.rand(len(d)) < d['p_accepted'].values].copy()
+        return d
 
     def get_priors(self, data):
         """Obtain priors on certain hidden variable dimensions, to obtain more

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -202,7 +202,7 @@ class LogLikelihood:
             self.default_bounds = dict()
 
         if mu_estimators is None:
-            mu_estimators = fd.CrossInterpolator
+            mu_estimators = fd.CrossInterpolatedMu
         if not isinstance(mu_estimators, dict):
             # Use the same mu estimator for all the sources
             # TODO: if the estimator is already built, check there is

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -224,7 +224,7 @@ class SpatialRateEnergySpectrum(FixedShapeEnergySpectrum):
 
         # Normalize the histogram
         self.spatial_hist.histogram = \
-            self.spatial_hist.histogram.astype(np.float) / self.spatial_hist.n
+            self.spatial_hist.histogram.astype(float) / self.spatial_hist.n
 
         # Local rate multiplier = PDF / uniform PDF
         # = ((normed_hist/bin_volumes) / (1/total_volume))

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -2,6 +2,7 @@
 Routines for estimating the total expected events
 and its variation with parameters.
 """
+from functools import partial
 
 import numpy as np
 from tqdm import tqdm
@@ -18,21 +19,28 @@ class MuEstimator:
 
     n_trials = int(1e5)  # Number of trials per mu simulation
     progress = True      # Whether to show progress bar during building
+    options: dict
+    bounds: dict
+    param_options: dict  # dict param -> dict of options per parameter
 
     def __init__(
             self,
             source: fd.Source,
             n_trials=None,
             progress=None,
+            options=None,
             **param_specs):
         if n_trials is not None:
             self.n_trials = n_trials
         if progress is not None:
             self.progress = progress
+        if options is None:
+            options = dict()
+        self.options = options
 
         # Extract bounds and options (like n_anchors) from param_specs
         self.bounds = dict()
-        self.options = dict()
+        self.param_options = dict()
         for pname, spec in param_specs.items():
             assert len(spec) in (2, 3)
             # Explicit type casting here, to avoid confusing tensorflow device
@@ -45,7 +53,7 @@ class MuEstimator:
                     # Backwards compatibility: the third element used to be
                     # number of anchors
                     opts = dict(n_anchors=spec[2])
-                self.options[pname] = opts
+                self.param_options[pname] = opts
 
         # Remove parameters the source does not take
         # Consistent with Source.__init__, don't complain / discard silently.
@@ -63,7 +71,10 @@ class MuEstimator:
 
 
 @export
-class CrossInterpolator(MuEstimator):
+class CrossInterpolatedMu(MuEstimator):
+    """Build piecewise-linear estimates of the relative change in mu along
+    each single parameter, then multiply the relative changes.
+    """
 
     def build(self, source: fd.Source):
         # Estimate mu under the current defaults
@@ -77,7 +88,7 @@ class CrossInterpolator(MuEstimator):
         if self.progress:
             _iter = tqdm(_iter, desc="Estimating mus")
         for pname, (start, stop) in _iter:
-            n_anchors = int(self.options.get(pname, {}).get('n_anchors', 2))
+            n_anchors = int(self.param_options.get(pname, {}).get('n_anchors', 2))
             self.mus[pname] = tf.convert_to_tensor(
                  [source.estimate_mu(**{pname: x}, n_trials=self.n_trials)
                   for x in np.linspace(start, stop, n_anchors)],
@@ -95,8 +106,9 @@ class CrossInterpolator(MuEstimator):
 
 
 @export
-class SimulateEachCall(MuEstimator):
-    """Estimate the mu with a new simulation __every single call__!
+class SimulateEachCallMu(MuEstimator):
+    """Estimate the expected number of events with a new simulation
+    __every single call__.
 
     Use for debugging / if you know what you are getting into...
     """
@@ -106,3 +118,117 @@ class SimulateEachCall(MuEstimator):
 
     def __call__(self, **kwargs):
         return self.source.estimate_mu(**kwargs)
+
+
+@export
+class ConstantMu(MuEstimator):
+    """Assume the expected number of events does not depend
+    on the fitted parameters
+    """
+    def build(self, source: fd.Source):
+        self.mu = source.estimate_mu(n_trials=self.n_trials)
+
+    def __call__(self, **kwargs):
+        return self.mu
+
+
+@export
+class CombinedMu(MuEstimator):
+    """Combine the results of different mu estimators for different subsets
+    of parameters. The final mu is the product of all relative changes.
+
+    Use e.g. as
+
+        est = fd.CombinedMu.from_estimators(
+            {
+                ('elife', 'g1'): fd.GridInterpolatedMu,
+                ('g2', 'single_electron_size'): fd.GridInterpolatedMu,
+            },
+            default=fd.CrossInterpolatedMu)
+        fd.LogLikelihood(..., mu_estimators=est)
+
+    This will setup two (2d) grid interpolators, and use cross interpolation
+    for the remaining parameters.
+    """
+    @classmethod
+    def from_estimators(cls, spec_dict, default=CrossInterpolatedMu):
+        return partial(cls, options=dict(spec_dict=spec_dict, default=default))
+
+    def build(self, source: fd.Source):
+        # Check the sub_estimators option is specified correctly
+        # Note we copy self.options['spec_dict'], since we mutate it later
+        assert self.options.get('spec_dict'), "Use CombinedMu.from_estimators"
+        spec_dict = {**self.options['spec_dict']}
+        params_specified = sum([spec['params'] for spec in spec_dict])
+        if len(set(params_specified)) != len(params_specified):
+            raise ValueError("CombinedMu specification duplicates parameters")
+
+        # Add a specification for the default estimator
+        missing_params = set(self.bounds.keys()) - set(params_specified)
+        if missing_params:
+            spec_dict[tuple(missing_params)] = self.options['default']
+
+        # Build sub-estimators (for different parameter sets)
+        self.estimators = []
+        for spec, est in spec_dict.items():
+            if isinstance(est, fd.MuEstimator):
+                # Already-initialized estimator, e.g. loaded from pickle
+                self.estimators.append(est)
+                continue
+            # Have to build this sub-estimator -- collect its options
+            if isinstance(est, dict):
+                # We got a dictionary specifying estimator class and options
+                est_class = est['class']
+                est_options = est.get('options', dict())
+                n_trials = est.get('n_trials', self.n_trials)
+                progress = est.get('progress', self.progress)
+            elif issubclass(est, fd.MuEstimator):
+                # We just got a class name -- use default options
+                est_class = est
+                est_options = est.get('options', dict())
+                n_trials = self.n_trials
+                progress = self.progress
+            else:
+                raise ValueError(f"Can't build mu estimator for {spec},"
+                                 f" {est} is not a mu estimator?")
+
+            # Create pname -> (min, max, options) dict for this estimator
+            param_specs = {
+                pname: self.bounds[pname] + (self.param_options[pname],)
+                for pname in spec['params']}
+            # Finally, build the estimator
+            self.estimators.append(est_class)(
+                source=self.source,
+                n_trials=n_trials,
+                progress=progress,
+                options=est_options,
+                **param_specs
+            )
+
+        # Get base mus: mus estimated at the default values by the different
+        # estimators
+        self.base_mus = [e() for e in self.estimators]
+        # Compute the mean. TODO: weight appropriately if n_trials varies?
+        self.mean_base_mu = float(np.mean(self.base_mus))
+
+    def __call__(self, **kwargs):
+        # Predicted mus by each estimator
+        pred_mus = [
+            est(**{k: v for k, v in kwargs.items() if k in spec['params']})
+            for est, spec in self.options['sub_estimator_specs'].items()]
+        # Relative increase over base mu
+        pred_increase = [
+            pred_mu / base_mu
+            for pred_mu, base_mu in zip(pred_mus, self.base_mus)
+        ]
+        # Multiply the mean base mu by all the relative increases
+        # to get the combined mu estimate
+        return self.mean_base_mu * tf.math.reduce_prod(pred_increase)
+
+
+@export
+class GridInterpolatedMu:
+    """Linearly interpolate the estimated mu on an n-dimensional grid"""
+
+    def build(self, source: fd.Source):
+        raise NotImplementedError

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -1,0 +1,102 @@
+"""
+Routines for estimating the total expected events
+and its variation with parameters.
+"""
+
+import numpy as np
+from tqdm import tqdm
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+import flamedisx as fd
+
+export, __all__ = fd.exporter()
+
+
+@export
+class MuEstimator:
+
+    n_trials = int(1e5)  # Number of trials per mu simulation
+    progress = True      # Whether to show progress bar during building
+
+    def __init__(
+            self,
+            source: fd.Source,
+            n_trials=None,
+            progress=None,
+            **param_specs):
+        if n_trials is not None:
+            self.n_trials = n_trials
+        if progress is not None:
+            self.progress = progress
+
+        # Extract bounds and options (like n_anchors) from param_specs
+        self.bounds = dict()
+        self.options = dict()
+        for pname, spec in param_specs.items():
+            assert len(spec) in (2, 3)
+            # Explicit type casting here, to avoid confusing tensorflow device
+            # placement messages if users mix up ints and floats
+            self.bounds[pname] = float(spec[0]), float(spec[1])
+            if len(spec) == 3:
+                self.options[pname] = spec[2]
+
+        # Remove parameters the source does not take
+        # Consistent with Source.__init__, don't complain / discard silently.
+        # MuEstimator.__call__, however, expects to be called with filtered params
+        param_specs = {k: v for k, v in param_specs.items() if k in source.defaults}
+
+        # Build the necessary interpolators
+        self.build(source)
+
+    def build(self, source: fd.Source):
+        raise NotImplementedError
+
+    def __call__(self, **params):
+        raise NotImplementedError
+
+
+@export
+class CrossInterpolator(MuEstimator):
+
+    def build(self, source: fd.Source):
+        # Estimate mu under the current defaults
+        self.base_mu = tf.constant(
+            source.estimate_mu(n_trials=self.n_trials),
+            dtype=fd.float_type())
+
+        # Estimate mu variation along each direction
+        self.mus = dict()   # parameter -> tensor of mus along anchors
+        _iter = self.bounds.items()
+        if self.progress:
+            _iter = tqdm(_iter, desc="Estimating mus")
+        for pname, (start, stop) in _iter:
+            n_anchors = int(self.options.get(pname, 2))
+            self.mus[pname] = tf.convert_to_tensor(
+                 [source.estimate_mu(**{pname: x}, n_trials=self.n_trials)
+                  for x in np.linspace(start, stop, n_anchors)],
+                 dtype=fd.float_type())
+
+    def __call__(self, **kwargs):
+        mu = self.base_mu
+        for pname, v in kwargs.items():
+            mu *= tfp.math.interp_regular_1d_grid(
+                x=v,
+                x_ref_min=self.bounds[pname][0],
+                x_ref_max=self.bounds[pname][1],
+                y_ref=self.mus[pname]) / self.base_mu
+        return mu
+
+
+@export
+class SimulateEachCall(MuEstimator):
+    """Estimate the mu with a new simulation __every single call__!
+
+    Use for debugging / if you know what you are getting into...
+    """
+
+    def build(self, source: fd.Source):
+        self.source = source
+
+    def __call__(self, **kwargs):
+        return self.source.estimate_mu(**kwargs)

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -39,7 +39,13 @@ class MuEstimator:
             # placement messages if users mix up ints and floats
             self.bounds[pname] = float(spec[0]), float(spec[1])
             if len(spec) == 3:
-                self.options[pname] = spec[2]
+                if isinstance(spec[2], dict):
+                    opts = spec[2]
+                else:
+                    # Backwards compatibility: the third element used to be
+                    # number of anchors
+                    opts = dict(n_anchors=spec[2])
+                self.options[pname] = opts
 
         # Remove parameters the source does not take
         # Consistent with Source.__init__, don't complain / discard silently.
@@ -71,7 +77,7 @@ class CrossInterpolator(MuEstimator):
         if self.progress:
             _iter = tqdm(_iter, desc="Estimating mus")
         for pname, (start, stop) in _iter:
-            n_anchors = int(self.options.get(pname, 2))
+            n_anchors = int(self.options.get(pname, {}).get('n_anchors', 2))
             self.mus[pname] = tf.convert_to_tensor(
                  [source.estimate_mu(**{pname: x}, n_trials=self.n_trials)
                   for x in np.linspace(start, stop, n_anchors)],

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -357,15 +357,15 @@ class Source:
         self.n_padding = 0
         self.n_events = len(self.data)
         self.n_batches = np.ceil(
-            self.n_events / self.batch_size).astype(np.int)
+            self.n_events / self.batch_size).astype(int)
 
         if not _skip_tf_init:
             # Extend dataframe with events to nearest batch_size multiple
             # We're using actual events for padding, since using zeros or
-            # nans caused problems with gradient calculation
-            # padded events are clipped when summing likelihood terms
+            # NaNs caused problems with gradient calculation.
+            # Padded events are clipped when summing likelihood terms.
             self.n_padding = self.n_batches * self.batch_size - len(self.data)
-            if self.n_padding > 0:
+            if self.n_padding:
                 # Repeat first event n_padding times and concat to rest of data
                 df_pad = self.data.iloc[np.zeros(self.n_padding)]
                 self.data = pd.concat([self.data, df_pad], ignore_index=True)
@@ -711,7 +711,7 @@ class Source:
         """
         if fix_truth is not None:
             for k, v in fix_truth.items():
-                data[k] = np.ones(n_events, dtype=np.float) * v
+                data[k] = np.ones(n_events, dtype=float) * v
 
     def estimate_mu(self, n_trials=int(1e5), **params):
         """Return estimate of total expected number of events
@@ -750,7 +750,8 @@ class Source:
 
     def random_truth(self, n_events, fix_truth=None, **params):
         """Draw random "deep truth" variables (energy, position) """
-        raise NotImplementedError
+        print(f"{self.__class__.__name__} cannot generate events, skipping")
+        return pd.DataFrame()
 
     def _simulate_response(self) -> pd.DataFrame:
         """Return a dataframe with simulated observed events
@@ -764,6 +765,9 @@ class Source:
         will call this when needed.
         """
         return self.data
+
+    def calculate_dimsizes_special(self):
+        pass
 
 
 @export
@@ -789,10 +793,3 @@ class ColumnSource(Source):
 
     def _differential_rate(self, data_tensor, ptensor):
         return self._fetch(self.column, data_tensor)
-
-    def random_truth(self, n_events, fix_truth=None, **params):
-        print(f"{self.__class__.__name__} cannot generate events, skipping")
-        return pd.DataFrame()
-
-    def calculate_dimsizes_special(self):
-        pass

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -687,6 +687,9 @@ class Source:
                                    keep_padding=keep_padding, **params):
             # Do the forward simulation of the detector response
             d = self._simulate_response()
+            if 'p_accepted' in d.columns:
+                # Draw which events are accepted
+                d = d.iloc[np.random.rand(len(d)) < d['p_accepted'].values].copy()
             if full_annotate:
                 # Now that we have s1 and s2 values, we can populate
                 # columns like e_vis, photon_produced_mle, etc.
@@ -804,9 +807,18 @@ class Source:
         """Draw random "deep truth" variables (energy, position) """
         raise NotImplementedError
 
-    def _simulate_response(self):
-        """Do a forward simulation of the detector response, using self.data"""
-        return self.data
+    def _simulate_response(self) -> pd.DataFrame:
+        """Return a dataframe with simulated observed events
+        from a simulation of the detector response.
+
+        You may include a p_accepted column with probabilities
+        that an event survives cuts.
+        You may have to set this to 0, of course.
+
+        Do not call or duplicate annotate_data: other functions
+        will call this when needed.
+        """
+        raise NotImplementedError
 
 
 @export

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -7,7 +7,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-import tensorflow_probability as tfp
 from scipy import stats
 
 from tqdm import tqdm

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -394,6 +394,12 @@ class Source:
         """Set self.data_tensor to a big tensor of shape:
           (n_batches, events_per_batch, n_columns_in_data_tensor)
         """
+        shape = [self.n_batches, self.batch_size, self.n_columns_in_data_tensor]
+        if not self.column_index:
+            # We want no columns from the data, so
+            self.data_tensor = tf.zeros(shape, dtype=fd.float_type())
+            return
+
         # First, build a list of (n_events, 1 or column_width) tensors
         result = []
         for column in self.column_index:
@@ -415,9 +421,7 @@ class Source:
 
         # Concat these and shape them to the batch size
         result = tf.concat(result, axis=1)
-        self.data_tensor = tf.reshape(
-            result,
-            [self.n_batches, -1, self.n_columns_in_data_tensor])
+        self.data_tensor = tf.reshape(result, shape)
 
     def cap_dimsizes(self, dim, cap):
         if dim in self.no_step_dimensions:

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -86,8 +86,8 @@ def test_multisource(xes: fd.ERSource):
         data=xes.data)
 
     # Prevent jitter from mu interpolator simulation to fail test
-    itp = lf.mu_itps['er']
-    lf2.mu_itps = dict(er=itp, er2=itp)
+    itp = lf.mu_estimators['er']
+    lf2.mu_estimators = dict(er=itp, er2=itp)
 
     np.testing.assert_allclose(lf2.log_likelihood()[0],
                                l1[0],
@@ -189,8 +189,8 @@ def test_multi_dset(xes: fd.ERSource):
                   data2=xes.data.copy()))
 
     # Fix interpolator nondeterminism
-    itp = lf.mu_itps['er']
-    lf2.mu_itps = dict(er1=itp, er2=itp)
+    itp = lf.mu_estimators['er']
+    lf2.mu_estimators = dict(er1=itp, er2=itp)
 
     ll2 = lf2()
 
@@ -281,8 +281,8 @@ def test_constraint(xes: fd.ERSource):
         data=xes.data.copy())
 
     # Fix interpolator nondeterminism
-    itp = lf.mu_itps['er']
-    lf2.mu_itps = dict(er=itp)
+    itp = lf.mu_estimators['er']
+    lf2.mu_estimators = dict(er=itp)
 
     ll2 = lf2()
 

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+
+import flamedisx as fd
+
+
+def mu_func(x=0, y=0):
+    return 42 + x + 1.2 * y + 0.5 * x * y
+
+
+class MuTestSource(fd.Source):
+    """Source for testing mu estimation"""
+
+    model_functions = ('our_mu',)
+
+    def mu_before_efficiencies(self, **params):
+        return self.our_mu(**params)
+
+    def estimate_mu(self, n_trials=None, **params):
+        # Let this source have perfect efficiency
+        # so we don't need MC trials
+        return self.mu_before_efficiencies(**params)
+
+    def _differential_rate(self, data_tensor, ptensor):
+        # Assume constant diff rates
+        return tf.ones(len(data_tensor))
+
+    def our_mu(self, x=0, y=0):
+        return mu_func(x, y)
+
+# Combining two cross interpolators
+# (the same as ordinary cross interpolation)
+double_cross = fd.CombinedMu.from_estimators(dict(
+    x=fd.CrossInterpolatedMu,
+    y=fd.CrossInterpolatedMu))
+
+ll_options = dict(
+    sources=dict(bla=MuTestSource),
+    data=pd.DataFrame([]),
+    x=(-1, 1),
+    y=(-1, 1),
+    batch_size=1)
+
+
+def test_cross_interpolation():
+    ll = fd.LogLikelihood(**ll_options, mu_estimators=fd.CrossInterpolatedMu)
+
+    # Interpolate one variable
+    mu_est = -ll(x=0.5)
+    base_mu = mu_func(0)
+    assert np.isclose(mu_est, base_mu * np.interp(
+        0.5,
+        [-1, 1],
+        [mu_func(-1)/base_mu, mu_func(1)/base_mu]))
+
+    # Interpolate both variables
+    mu_est = -ll(x=0.5, y=0.3)
+    assert np.isclose(mu_est, (
+        base_mu
+        * np.interp(0.5, [-1, 1], [mu_func(-1)/base_mu, mu_func(1)/base_mu])
+        * np.interp(0.3, [-1, 1], [mu_func(0, -1)/base_mu, mu_func(0, 1)/base_mu])))
+
+
+def test_double_cross():
+    # Combining cross interpolators is the same as doing
+    # one big cross interpolation
+    # (because cross interpolators and CombinedEstimator both
+    #  multiply independently estimated relative changes)
+    ll_1 = fd.LogLikelihood(**ll_options, mu_estimators=double_cross)
+    ll_2 = fd.LogLikelihood(**ll_options, mu_estimators=fd.CrossInterpolatedMu)
+
+    assert np.isclose(ll_1(x=0.3, y=-0.2), ll_2(x=0.3, y=-0.2))
+
+
+def test_constant_mu():
+    # On a source with constant mu, all mu estimation methods
+    # should give the same results.
+
+    class ConstantMuSource(MuTestSource):
+        def our_mu(self, x=1, y=1):
+            return 42
+
+    test_estimators = [
+        fd.ConstantMu,
+        fd.CrossInterpolatedMu,
+        double_cross
+    ]
+
+    opts = {**ll_options}
+    opts['sources'] = dict(bla=ConstantMuSource)
+
+    for mu_est in test_estimators:
+        print(f"Testing {mu_est}...")
+        assert fd.LogLikelihood(**opts, mu_estimators=mu_est)() == -42
+        print(f"Testing {mu_est} succeeded!")


### PR DESCRIPTION
This expands flamedisx's options for estimating the total expected events ('mu'). It mostly prepares the ground for implementing new mu estimation methods in the near future, rather than adding new methods.


Specifying different mu estimation methods
----------------------------------------------------------
See issue #71. A new `mu_estimators` argument to `Likelihood.__init__` controls how mu estimators are built:
  * `fd.CrossInterpolatedMu` (the default) will use the current algorithm.
  * `fd.SimulateEachCallMu` does a completely new simulation each call. This does not actually work -- it makes the likelihood non-differentiable. But it could be useful for debugging, or for future developement (I think Pueh is looking into this)
  * `fd.ConstantMu` assumes mu is a constant. Perhaps useful to separate different contributions to the likelihood.
  * You can pass an already-built dictionary of mu interpolators, e.g. loaded from disk (see next section);
  * If you have multiple sources in the likelihood, and want to use different mu estimation methods for each, pass a dictionary mapping source names to the options above.
  * Finally, `fd.CombinedMu` uses different mu estimators for different parameter subsets. For example, this will setup two independent 2d grid interpolators, and use cross interpolation for the remaining parameters:
```
est = fd.CombinedMu.from_estimators(
    {('elife', 'g1'): fd.GridInterpolatedMu,
     ('g2', 'single_electron_size'): fd.GridInterpolatedMu},
    default=fd.CrossInterpolatedMu)
fd.LogLikelihood(..., mu_estimators=est)
```

The actual code for mu estimation now lives in a new file (`mu_estimation.py`) which contains classes for the different methods. Currently it's a short list, but we can start adding to this. `Source`s no longer have a `mu_function` method; they are only responsible for `estimate_mu` at one parameter combination.

This PR also generalizes the third element in parameter specifications. Currently this is a number of anchors:

```python
ll = fd.LogLikelihood(
    sources=dict(er=fd.ERSource),
    elife=(300e3, 500e3, 2),)
```

This remains supported for backwards compatibility. However, an anchor count is not meaningful for all mu estimation methods. Instead, you can omit the third element (fd.CrossInterpolation will use 2 anchors by default):

```python
ll = fd.LogLikelihood(
    sources=dict(er=fd.ERSource),
    elife=(300e3, 500e3),)
```

or pass a dictionary, in which you can put other options as well:

```python
ll = fd.LogLikelihood(
    sources=dict(er=fd.ERSource),
    elife=(300e3, 500e3, dict(n_anchors=2),)
```


Saving and loading mu estimators
-----------------------------------------------
See issue #52. Now that we're going to spend more computation time on the mu estimation, we don't want to redo that work every time we start a notebook.

You can set the new `mu_estimators` argument to a previously built mu_estimators dictionary. For example,

```python
ll = fd.LogLikelihood(....)

# Saving to disk
fn = 'bla.pkl'
with pickle.open(fn, mode='wb') as f:
    pickle.dump(f, ll.mu_estimators)
    
# Loading from disk
with pickle.open(fn, mode='rb') as f:
    mu_estimators = pickle.load(f)
ll = fd.LogLikelihood(...., mu_estimators=mu_estimators)
```

Maybe we want to build something more opinionated (a la blueice) on top of this later, or maybe simpler is better for now.

I would still like to add a few unit tests.