### PR TITLE
Exposure in wimp source

### DIFF
--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -330,6 +330,7 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
     def setup(self):
         wimp_kwargs = dict(mw=self.mw,
                            sigma_nucleon=self.sigma_nucleon,
+                           exposure_tonneyear=self.exposure_tonneyear,
                            energy_edges=self.energy_edges)
 
         # BlockModelSource is kind enough to let us change these attributes
@@ -345,7 +346,8 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
 
         # Transform wimp_kwargs to arguments that can be passed to wimprates
         # which means transforming es from edges to centers
-        del wimp_kwargs['energy_edges']
+        del wimp_kwargs['energy_edges'], wimp_kwargs['exposure_tonneyear']
+
         spectra = np.array([wr.rate_wimp_std(t=t,
                                              es=e_centers,
                                              **wimp_kwargs)

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -300,6 +300,7 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
     model_attributes = ('pretend_wimps_dont_modulate',
                         'mw',
                         'sigma_nucleon',
+                        'exposure_tonneyear',
                         'n_time_bins',
                         'energy_edges') + VariableEnergySpectrum.model_attributes
 
@@ -315,6 +316,9 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
 
     #: Number of time bins to use for annual modulation computation
     n_time_bins = 24
+
+    #: Exposure in tonne year
+    exposure_tonneyear = 1.
 
     #: Bin *edges* to use for energy histogram. Centers of the bins correspond
     #: to allowed energies.
@@ -351,7 +355,7 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
 
         self.energy_hist = Histdd.from_histogram(
             spectra,
-            bin_edges=(times, self.energy_edges))
+            bin_edges=(times, self.energy_edges)) * exposure_tonneyear
 
         if self.pretend_wimps_dont_modulate:
             self.energy_hist.histogram = (

--- a/flamedisx/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/lxe_blocks/energy_spectrum.py
@@ -357,7 +357,7 @@ class WIMPEnergySpectrum(VariableEnergySpectrum):
 
         self.energy_hist = Histdd.from_histogram(
             spectra,
-            bin_edges=(times, self.energy_edges)) * exposure_tonneyear
+            bin_edges=(times, self.energy_edges)) * self.exposure_tonneyear
 
         if self.pretend_wimps_dont_modulate:
             self.energy_hist.histogram = (


### PR DESCRIPTION
## What? Why?
This pull request introduces another class variable `exposure_tonneyear` to the `WIMPEnergySpectrum` class so that it is easier to change the exposure of the WIMP source.

## How?
The spectra computed by `wimprates.rate_wimp_std` is in the units of events / (keV tonne year) and it is scaled by the exposure in units of tonne year [in this line](https://github.com/FlamTeam/flamedisx/blob/d371b34db4de2256f3697a5e08d02e260ef40787/flamedisx/lxe_blocks/energy_spectrum.py#L358).

The way to scaling the WIMP rate is inspired by @pelssers's [sensitivity studies notebook](https://github.com/FlamTeam/flamedisx-notebooks/blob/b8acfdf8fcc2c191fe1882706466c442e46a92ed/flamedisx_sensitivity.ipynb). He tried to scale the spectrum from the class but there is a comment that suggests that that would not work because 'populate tensor cache is already called so has no effect' so in this PR, the scaling factor is introduced to `WIMPEnergySpectrum` instead.

## Testing? Screenshots (optional)
The changes are tested using the a class which inherits from `fd.SR1WIMPSource` and with the class variables overwritten as such:
```
class wimp_variable_f2(fd.SR1WIMPSource):
    variable_drift_field = True
    
    mw = this_mw
    sigma_nucleon = this_sigma_nucleon
    energy_edges = np.geomspace(0.7, 50., 100) # sticking to default values
    exposure_tonneyear = this_exposure
    
    #'''
    pretend_wimps_dont_modulate = False
    n_time_bins = 24
    #'''
    '''
    pretend_wimps_dont_modulate = True
    n_time_bins = 1
    #'''
```
Setting the exposure to 4 tonne * 10./365. years, the ~38 expected number of 50 GeV WIMP events(cross section 1e-45 cm2/nucleon) is obtained, which is equivalent to ~348 events, which is the number of expected WIMP events given 1 tonne year of exposure (default, no scaling).
![Screenshot from 2022-05-13 19-08-44](https://user-images.githubusercontent.com/46324102/168338640-eaa42eec-84ce-4294-bcfc-144f679aac12.png)