### PR TITLE
Add simple fixed template source

### DIFF
--- a/flamedisx/__init__.py
+++ b/flamedisx/__init__.py
@@ -3,6 +3,7 @@ __version__ = '2.0.0'
 from .utils import *
 from .source import *
 from .block_source import *
+from .templates import *
 from .likelihood import *
 from .inference import *
 from .bounds import *

--- a/flamedisx/templates.py
+++ b/flamedisx/templates.py
@@ -1,0 +1,112 @@
+import tensorflow as tf
+from multihist import Histdd
+import pandas as pd
+
+import flamedisx as fd
+
+export, __all__ = fd.exporter()
+
+
+@export
+class TemplateSource(fd.Source):
+    """Source that looks up precomputed differential rates in a template
+    (probably a histogram from a simulation).
+
+    Arguments:
+        - template: numpy array, multhist.Histdd, or (hist/boost_histogram).
+            containing the differential rate.
+        - bin_edges: None, or a list of numpy arrays with bin edges.
+            If None, get this info from template.
+        - axis_names: None, or a sequence of axis names.
+            If None, get this info from template.
+        - events_per_bin: set to True if template specifies expected events per
+            bin, rather than differential rate.
+
+    For other arguments, see flamedisx.source.Source
+    """
+
+    def __init__(
+            self,
+            template,
+            bin_edges=None,
+            axis_names=None,
+            events_per_bin=False,
+            *args,
+            **kwargs):
+        # Get template, bin_edges, and axis_names
+        if bin_edges is None:
+            # Hopefully we got some kind of histogram container
+            if isinstance(template, tuple) and len(template) == 2:
+                # (hist, bin_edges) tuple, e.g. from np.histdd
+                template, bin_edges = template
+            elif hasattr(template, "to_numpy"):
+                # boost_histogram / hist
+                if not axis_names:
+                    axis_names = [ax.name for ax in template.axes]
+                template, bin_edges = template.to_numpy()
+            elif hasattr(template, "bin_edges"):
+                # multihist
+                if not axis_names:
+                    axis_names = template.axis_names
+                template, bin_edges = template.histogram, template.bin_edges
+            else:
+                raise ValueError("Need histogram, bin_edges, and axis_names")
+        if not axis_names or len(axis_names) != len(template.shape):
+            raise ValueError("Axis names missing or mismatched")
+
+        # Use multihist's bin volume and centers helpers
+        self._mh = Histdd.from_histogram(template, bin_edges=bin_edges)
+
+        if events_per_bin:
+            # Histogram is events/bin
+            diff_rate = template / self._mh.bin_volumes()
+        else:
+            # Histogram is a diff rate
+            diff_rate = template
+            self._mh *= self._mh.bin_volumes()
+
+        self.mu = fd.np_to_tf(self._mh.n)
+        self.diff_rate = fd.np_to_tf(diff_rate)
+        self.bin_edges = fd.np_to_tf(bin_edges)
+        self.bin_centers = fd.np_to_tf(self._mh.bin_centers())
+        self.all_axis_bin_centers = fd.np_to_tf([
+            self._mh.all_axis_bin_centers(i)
+            for i in range(len(axis_names))])
+        self.final_dimensions = axis_names
+
+        super().__init__(*args, **kwargs)
+
+    def estimate_mu(self, n_trials=None, **params):
+        return self.mu
+
+    def _differential_rate(self, data_tensor, ptensor):
+        # Find indices of observed events
+        indices = [
+            # -1 since bin number 0 is past 1 edge
+            tf.clip_by_value(
+                -1 + tf.searchsorted(
+                    self.bin_edges[dim_i],
+                    self._fetch(dim, data_tensor)),
+                0,
+                len(self.bin_edges[dim_i] - 2)
+            )
+            for dim_i, dim in enumerate(self.final_dimensions)
+        ]
+        # Look them up in the template
+        return tf.gather_nd(self.diff_rate, tf.stack(indices, axis=-1))
+
+    def simulate(self, n_events, fix_truth=None, full_annotate=False,
+                 keep_padding=False, **params):
+        """Simulate n events.
+        """
+        if fix_truth:
+            raise NotImplementedError("HistogramSource does not yet support fix_truth")
+        assert isinstance(n_events, (int, float)), \
+            f"n_events must be an int or float, not {type(n_events)}"
+
+        # TODO: all other arguments are ignored, they make no sense
+        # for this source. Should we warn about this? Remove them from def?
+
+        return pd.DataFrame(dict(zip(
+            self.final_dimensions,
+            self._mh.get_random(n_events).T)))

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -24,7 +24,6 @@ def test_template():
     # TODO: should set seed...
     d2 = st.simulate(int(1e6))
     mh2 = Histdd(d2, axis_names=['s1', 's2'], bins=mh.bin_edges)
-    mh2.plot()
     assert np.abs(np.mean(
         (mh2.histogram - mh.histogram)
         /(mh.histogram + mh2.histogram + 0.1))) < 0.1

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,33 @@
+import flamedisx as fd
+import numpy as np
+
+from multihist import Histdd
+
+
+def test_template():
+    # Create a template source from 1e6 ERSource events
+    s = fd.ERSource()
+    d = s.simulate(int(1e6))
+    mh = Histdd(d['s1'], d['s2'], bins=30, axis_names=['s1', 's2'])
+    st = fd.TemplateSource(mh, events_per_bin=True, batch_size=int(1e3))
+
+    # Test differential rate equals the result from a simple lookup
+    # (in the differential rate histogram, i.e. divide hist by bin volumes)
+    d = st.simulate(1020)
+    st.set_data(d)
+    assert np.allclose(
+        st.batched_differential_rate(),
+        (mh / mh.bin_volumes()).lookup(d['s1'], d['s2']))
+
+    # Simulate data from the template source,
+    # ensuring the distribution remains similar
+    # TODO: should set seed...
+    d2 = st.simulate(int(1e6))
+    mh2 = Histdd(d2, axis_names=['s1', 's2'], bins=mh.bin_edges)
+    mh2.plot()
+    assert np.abs(np.mean(
+        (mh2.histogram - mh.histogram)
+        /(mh.histogram + mh2.histogram + 0.1))) < 0.1
+
+    # Total events should equal the histogram sum
+    assert np.isclose(st.estimate_mu().numpy(), mh.n)


### PR DESCRIPTION
This allows users to specify sources using histograms that contain expected events/bin or differential rates. This is useful for sources like accidental coincides that have empirical models, and for cross-checks on the main flamedisx computation. Here's an example:
```python
source = fd.TemplateSource(some_multihist, events_per_bin=True, batch_size=int(1e3))
```
where `some_multihist` is a [multihist](https://github.com/JelleAalbers/multihist) Histdd. You should also be able to pass a [boost-histogram](https://github.com/scikit-hep/boost-histogram) or [hist](https://github.com/scikit-hep/hist) object, though I haven't tested this. Or you can just pass `template`, `bin_edges`, `axis_names` explicitly, setting the former two to numpy arrays and the final one to a sequence of strings. 

For a more complete example, see the [unit test](https://github.com/FlamTeam/flamedisx/blob/template_source/tests/test_template.py#L8).

When using a TemplateSource in a likelihood, you'll want to pass the template in via the `arguments` argument to LogLikelihood, or sneak it in via `functools.partial`. I haven't tested this though. We should probably make an example/tutorial that uses templates.

`TemplateSource` can simulate events, but it only simulates for dimensions that the histogram has. For example, a template source with a (cs1, cs2) histogram won't magically simulate raw (s1, s2) or uniform positions and times. If desired, this should be easy to add by making a TemplateSource subclass, and code like [here](https://github.com/FlamTeam/flamedisx/blob/main/flamedisx/lxe_blocks/energy_spectrum.py#L58).

A basic `TemplateSource` has no parameters, though if used in a likelihood you can fit its rate multiplier. In the future we can enable shape parameters / linear template morphing with [tfp.math.batch_interp_rectilinear_nd_grid](https://www.tensorflow.org/probability/api_docs/python/tfp/math/batch_interp_rectilinear_nd_grid) or [tfp.math.batch_interp_regular_nd_grid](https://www.tensorflow.org/probability/api_docs/python/tfp/math/batch_interp_regular_nd_grid) from tensorflow-probability.
