### PR TITLE
Rj grid interpolation

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -54,7 +54,7 @@ class LogLikelihood:
             batch_size=10,
             max_sigma=None,
             max_sigma_outer=None,
-            n_trials=int(1e5),
+            n_trials=None,
             log_constraint=None,
             bounds_specified=True,
             progress=True,

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -243,9 +243,11 @@ class GridInterpolatedMu(MuEstimator):
 
         param_lowers = []
         param_uppers = []
+        grid_shape = ()
         for pname, (start, stop) in _iter:
             param_lowers.append(start)
             param_uppers.append(stop)
+            grid_shape += (int(self.param_options.get(pname, {}).get('n_anchors', 2)),)
 
         self.param_lowers = param_lowers
         self.param_uppers = param_uppers
@@ -259,12 +261,13 @@ class GridInterpolatedMu(MuEstimator):
         mu_grid = []
         for params in param_grid:
             mu_grid.append(source.estimate_mu(**params, n_trials=self.n_trials))
-        mu_grid = np.array_split(mu_grid, 3)
+        mu_grid = np.asarray(mu_grid).reshape(grid_shape)
 
         self.mu_grid = tf.convert_to_tensor(mu_grid, fd.float_type())
 
     def __call__(self, **kwargs):
-        assert(dict(sorted(self.bounds.items())).keys() == dict(sorted(kwargs.items())).keys())
+        assert(dict(sorted(self.bounds.items())).keys() == dict(sorted(kwargs.items())).keys()), \
+            "Must pass the same parameters to the grid interpolator that the grid was built with"
 
         n_params = len(kwargs)
         params = []

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -252,7 +252,9 @@ class GridInterpolatedMu(MuEstimator):
         self.param_lowers = param_lowers
         self.param_uppers = param_uppers
 
-        grid_dict = {pname: np.linspace(start, stop, int(self.param_options.get(pname, {}).get('n_anchors', 3))) for pname, (start, stop) in _iter}
+        grid_dict = {pname: np.linspace(start, stop,
+                                        int(self.param_options.get(pname, {}).get('n_anchors', 3)))
+                     for pname, (start, stop) in _iter}
         param_grid = list(ParameterGrid(grid_dict))
 
         if self.progress:
@@ -279,6 +281,7 @@ class GridInterpolatedMu(MuEstimator):
                                                      x_ref_max=self.param_uppers,
                                                      y_ref=self.mu_grid,
                                                      axis=-n_params)[0]
+
 
 @export
 def is_mu_estimator_class(x):

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -247,12 +247,12 @@ class GridInterpolatedMu(MuEstimator):
         for pname, (start, stop) in _iter:
             param_lowers.append(start)
             param_uppers.append(stop)
-            grid_shape += (int(self.param_options.get(pname, {}).get('n_anchors', 2)),)
+            grid_shape += (int(self.param_options.get(pname, {}).get('n_anchors', 3)),)
 
         self.param_lowers = param_lowers
         self.param_uppers = param_uppers
 
-        grid_dict = {pname: np.linspace(start, stop, int(self.param_options.get(pname, {}).get('n_anchors', 2))) for pname, (start, stop) in _iter}
+        grid_dict = {pname: np.linspace(start, stop, int(self.param_options.get(pname, {}).get('n_anchors', 3))) for pname, (start, stop) in _iter}
         param_grid = list(ParameterGrid(grid_dict))
 
         if self.progress:

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -238,6 +238,12 @@ class CombinedMu(MuEstimator):
 class GridInterpolatedMu(MuEstimator):
     """Linearly interpolate the estimated mu on an n-dimensional grid"""
 
+    def __init__(self, *args, **kwargs):
+        if ('n_trials' not in kwargs) or (kwargs['n_trials'] is None):
+            kwargs['n_trials'] = int(1e6)
+
+        super().__init__(*args, **kwargs)
+
     def build(self, source: fd.Source):
         param_lowers = []
         param_uppers = []
@@ -246,7 +252,7 @@ class GridInterpolatedMu(MuEstimator):
         for pname, (start, stop) in self.bounds.items():
             param_lowers.append(start)
             param_uppers.append(stop)
-            n_anchors = int(self.param_options.get(pname, {}).get('n_anchors', 2))
+            n_anchors = int(self.param_options.get(pname, {}).get('n_anchors', 3))
             grid_shape += (n_anchors,)
             grid_dict[pname] = np.linspace(start, stop, n_anchors)
 

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -7,3 +7,4 @@ tqdm
 tensorflow>=2.2.0
 tensorflow_probability>=0.8.0
 iminuit
+sklearn

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -62,11 +62,6 @@ def test_cross_interpolation():
         * np.interp(0.5, [-1, 1], [mu_func(-1)/base_mu, mu_func(1)/base_mu])
         * np.interp(0.3, [-1, 1], [mu_func(0, -1)/base_mu, mu_func(0, 1)/base_mu])))
 
-    # Check that we agree exactly at the cross centre
-    mu_est_centre = -ll(x=0, y=0)
-
-    assert np.isclose(mu_est_centre, mu_func(0, 0))
-
 
 def test_double_cross():
     # Combining cross interpolators is the same as doing

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -105,7 +105,7 @@ def test_grid_interpolation():
     # Interpolate both variables
     mu_est = -ll(x=0.5, y=0.3)
 
-    points = ([-1, 1], [-1, 1])
+    points = ([-1, 0, 1], [-1, 0, 1])
     mu_grid = mu_func(*np.meshgrid(*points, indexing='ij'))
 
     assert np.isclose(mu_est, interpn(points, mu_grid, np.array([0.5, 0.3])))


### PR DESCRIPTION
This PR adds a grid interpolation option. The default number of anchors for a grid interpolated parameter is 3; cross interpolation automatically probes the centre in a roundabout way, but a 2-anchor grid interpolation would not, hence this choice.

As a benchmark, I did a fit with the Xe1T SR1 ER source (@plt109), for g1, gamma_er and omega_er. I used 2 anchors (plus the base mu at the centre) for grid interpolation, and 3 anchors for cross interpolation. Each anchor point had 10^6 simulated events to estimate mu.

The percentage differences between the interpolated and directly estimated mu in each case, at 3 benchmark points, are:

**Cross:**

Bestfit: 7.1%
Lower range for all: 9.4%
Central defaults for all: 4.4%

**Grid:**

Bestfit: 0.13%
Lower range for all: 0.22%
Central defaults for all: 0.045%

I added a couple of unit tests. I still want to test combining cross and grid interpolators.