### PR TITLE
Rj new er models

### DIFF
--- a/flamedisx/lux/lux.py
+++ b/flamedisx/lux/lux.py
@@ -84,6 +84,12 @@ class LUXERSource(LUXSource, fd.nest.nestERSource):
 
 
 @export
+class LUXGammaSource(LUXSource, fd.nest.nestGammaSource):
+    def __init__(self, *args, detector='default', **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@export
 class LUXNRSource(LUXSource, fd.nest.nestNRSource):
     def __init__(self, *args, detector='default', **kwargs):
         super().__init__(*args, **kwargs)

--- a/flamedisx/lux/lux.py
+++ b/flamedisx/lux/lux.py
@@ -90,6 +90,12 @@ class LUXGammaSource(LUXSource, fd.nest.nestGammaSource):
 
 
 @export
+class LUXERGammaWeightedSource(LUXSource, fd.nest.nestERGammaWeightedSource):
+    def __init__(self, *args, detector='default', **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@export
 class LUXNRSource(LUXSource, fd.nest.nestNRSource):
     def __init__(self, *args, detector='default', **kwargs):
         super().__init__(*args, **kwargs)

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -483,13 +483,13 @@ class nestERGammaWeightedSource(nestERSource):
         weight_param_e = 421.15
         weight_param_f = 3.27
 
-        weightG = weight_param_a + weight_param_b * tf.math.erf(weight_param_c *
+        weightG = tf.cast(weight_param_a + weight_param_b * tf.math.erf(weight_param_c *
             (tf.math.log(energy) + weight_param_d)) * \
-            (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f))))
-        weightB = 1. - weightG
+            (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f)))), fd.float_type())
+        weightB = tf.cast(1. - weightG, fd.float_type())
 
-        nel_gamma = nestGammaSource.mean_yield_electron(self, energy)
-        nel_beta = nestERSource.mean_yield_electron(self, energy)
+        nel_gamma = tf.cast(nestGammaSource.mean_yield_electron(self, energy), fd.float_type())
+        nel_beta = tf.cast(nestERSource.mean_yield_electron(self, energy), fd.float_type())
 
         return nel_gamma * weightG + nel_beta * weightB
 

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -441,6 +441,36 @@ class nestNRSource(nestSource):
 
 
 @export
+class nestGammaSource(nestERSource):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def mean_yield_electron(self, energy):
+        Wq_eV = self.Wq_keV * 1e3
+        m3 = 2.
+        m4 = 2.
+        m6 = 0.
+
+        m1 = 33.951 + (3.3284 - 33.951) / (1. + pow(self.drift_field / 165.34, .72665))
+        m2 = 1000 / Wq_eV
+        m5 = 23.156 + (10.737 - 23.156) / (1. + pow(self.drift_field / 34.195, .87459))
+        densCorr = 240720. / pow(self.density, 8.2076)
+        m7 = 66.825 + (829.25 - 66.825) / (1. + pow(self.drift_field / densCorr, .83344))
+
+        m8 = 2.
+
+        Qy = m1 + (m2 - m1) / (1. + pow(energy / m3, m4)) + m5 + (m6 - m5) / (1. + pow(energy / m7, m8))
+
+        nel_temp = Qy * energy
+        # Don't let number of electrons go negative
+        nel = tf.where(nel_temp < 0,
+                    0 * nel_temp,
+                    nel_temp)
+
+        return nel
+
+
+@export
 class nestSpatialRateERSource(nestERSource):
     model_blocks = (fd_nest.SpatialRateEnergySpectrum,) + nestERSource.model_blocks[1:]
 

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -464,8 +464,8 @@ class nestGammaSource(nestERSource):
         nel_temp = Qy * energy
         # Don't let number of electrons go negative
         nel = tf.where(nel_temp < 0,
-                    0 * nel_temp,
-                    nel_temp)
+                       0 * nel_temp,
+                       nel_temp)
 
         return nel
 
@@ -484,8 +484,9 @@ class nestERGammaWeightedSource(nestERSource):
         weight_param_f = 3.27
 
         weightG = tf.cast(weight_param_a + weight_param_b * tf.math.erf(weight_param_c *
-            (tf.math.log(energy) + weight_param_d)) * \
-            (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f)))), fd.float_type())
+                          (tf.math.log(energy) + weight_param_d)) *
+                          (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f)))),
+                          fd.float_type())
         weightB = tf.cast(1. - weightG, fd.float_type())
 
         nel_gamma = tf.cast(nestGammaSource.mean_yield_electron(self, energy), fd.float_type())

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -471,6 +471,30 @@ class nestGammaSource(nestERSource):
 
 
 @export
+class nestERGammaWeightedSource(nestERSource):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def mean_yield_electron(self, energy):
+        weight_param_a = 0.23
+        weight_param_b = 0.77
+        weight_param_c = 2.95
+        weight_param_d = -1.44
+        weight_param_e = 421.15
+        weight_param_f = 3.27
+
+        weightG = weight_param_a + weight_param_b * tf.math.erf(weight_param_c *
+            (tf.math.log(energy) + weight_param_d)) * \
+            (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f))))
+        weightB = 1. - weightG
+
+        nel_gamma = nestGammaSource.mean_yield_electron(self, energy)
+        nel_beta = nestERSource.mean_yield_electron(self, energy)
+
+        return nel_gamma * weightG + nel_beta * weightB
+
+
+@export
 class nestSpatialRateERSource(nestERSource):
     model_blocks = (fd_nest.SpatialRateEnergySpectrum,) + nestERSource.model_blocks[1:]
 


### PR DESCRIPTION
This PR adds in the NEST gamma model as well as the weighted beta/gamma model from NEST that has been shown well to fit to certain electron capture decays.

Validations attached below:

<img width="658" alt="photons_weighted_10keV" src="https://user-images.githubusercontent.com/57010144/186206169-6fc3105f-2d34-4d00-a1e3-f9b7f0f37f3b.png">

<img width="666" alt="electrons_weighted_10keV" src="https://user-images.githubusercontent.com/57010144/186206232-19162022-34ca-4183-9109-11f13229a0c3.png">

<img width="664" alt="s1_weighted_10keV" src="https://user-images.githubusercontent.com/57010144/186206271-6456f286-0e8b-4c89-a7d7-d6f927fea22f.png">

<img width="666" alt="s2_weighted_10keV" src="https://user-images.githubusercontent.com/57010144/186206299-b92d3198-4e3e-47df-aa96-e13584162270.png">

<img width="666" alt="weighted_10keV" src="https://user-images.githubusercontent.com/57010144/186206380-071cf373-319f-4ad5-b1d1-33a76c3b2d8a.png">

<img width="674" alt="s1_weighted_1keV" src="https://user-images.githubusercontent.com/57010144/186206417-aa714cfb-687a-4a30-b4cd-f7c2ceb2544b.png">

<img width="686" alt="s2_weighted_1keV" src="https://user-images.githubusercontent.com/57010144/186206429-3e1b3a29-4aeb-4351-9bdf-407d4e89e7f5.png">

<img width="670" alt="s1_weighted_100keV" src="https://user-images.githubusercontent.com/57010144/186206445-f047893c-ceff-40d5-9a18-98d96b918061.png">

<img width="642" alt="s2_weighted_100keV" src="https://user-images.githubusercontent.com/57010144/186206469-7b24085e-11bb-4085-83d0-98a6e5ef0a4b.png">