### PR TITLE
Allow for non-integer dimensions.

### DIFF
--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -32,6 +32,9 @@ class Block:
     #: _calculate_dimsizes_special().
     bonus_dimensions: ty.Tuple[ty.Tuple[str, bool]] = tuple()
 
+    #: inner_dimensions which take non-integer values
+    non_integer_dimensions: ty.Tuple[str] = tuple()
+
     #: Columns that we don't want to include in the tensor of data columns
     exclude_data_tensor: ty.Tuple[str] = tuple()
 
@@ -251,6 +254,7 @@ class BlockModelSource(fd.Source):
         # Collect attributes from the different blocks in this dictionary:
         collected = {k: [] for k in (
             'dimensions',
+            'non_integer_dimensions',
             'bonus_dimensions',
             'exclude_data_tensor',
             'model_functions',
@@ -326,6 +330,8 @@ class BlockModelSource(fd.Source):
                 continue
             setattr(self, k, getattr(self, k) + tuple(set(v)))
 
+        self.non_integer_dimensions = tuple([
+            d for d in collected['non_integer_dimensions']])
         self.inner_dimensions = tuple(
             [d for d in collected['dimensions']
                 if ((d not in self.final_dimensions)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -58,6 +58,9 @@ class Source:
     #: for which the domain is always a single interval of integers
     no_step_dimensions: ty.Tuple[str] = tuple()
 
+    #: inner_dimensions which take non-integer values
+    non_integer_dimensions: ty.Tuple[str] = tuple()
+
     #: Names of dimensions of hidden variables for which
     #: dimsize calculations are NOT done here (but in user-defined code)
     #: but for which we DO track _min and _dimsizes
@@ -444,6 +447,12 @@ class Source:
             steps = tf.where((ma-mi+1) > self.dimsizes[dim],
                              tf.math.ceil((ma-mi) / (self.dimsizes[dim]-1)),
                              1).numpy()  # Cover to at least the upper bound
+
+            # For non-integer dimensions, always set to max_dim_size, then step in non-integers
+            if dim in self.non_integer_dimensions:
+                self.dimsizes[dim] = self.max_dim_sizes[dim]
+                steps = (ma - mi) / (self.dimsizes[dim] - 1)
+
             # Store the steps in the dataframe
             d[dim + '_steps'] = steps
 


### PR DESCRIPTION
This PR enables support for dimensions which are non-integer: this will be especially useful for @plt109's (and later our) reconstruction bias.

Using it is simple: I made a toy example where the final dimension becomes `s1_smear`, giving a Gaussian smearing `s1_smear ~ Normal(s1, 0.01)`. Once this new block has been implemented, and the correct new final dimensions have been flagged up (as before), the only additional change needed is to add

`non_integer_dimensions = ('s1')`

in the source class.

I've attached a validation plot for this model (using a LUX ER source at 10 keV with this new S1 smearing block bolted on, and a `max_dim_size` of 200 for `s1`). I attach that below

![quantitative_comparison_er](https://user-images.githubusercontent.com/57010144/189185652-27fe2637-62c8-44c2-a90d-d08058675d21.png)