### PR TITLE
Add S2 threshold properly, as NEST does.

### DIFF
--- a/flamedisx/nest/config/default.ini
+++ b/flamedisx/nest/config/default.ini
@@ -29,12 +29,14 @@ gas_gap_config = 4.25 ; mm
 g1_gas_config = 0.1
 s2Fano_config = 3.6
 
+s2_thr_config = 192.295082
+
 S1_noise_config = 0.
 S2_noise_config = 0.
 
 
 ; Selection parameters
-S1_min_config = 0.38459016
+S1_min_config = 0.
 S1_max_config = 100000
-S2_min_config = 192.295082
+S2_min_config = 0.
 S2_max_config = 1000000000

--- a/flamedisx/nest/lxe_blocks/final_signals.py
+++ b/flamedisx/nest/lxe_blocks/final_signals.py
@@ -134,7 +134,7 @@ class MakeS2(MakeFinalSignals):
     max_dim_size = {'s2_photoelectrons_detected': 120}
 
     def s2_acceptance(self, s2):
-        return tf.where((s2 < self.source.S2_min) | (s2 > self.source.S2_max),
+        return tf.where((s2 < self.source.S2_min) | (s2 < self.source.s2_thr) | (s2 > self.source.S2_max),
                         tf.zeros_like(s2, dtype=fd.float_type()),
                         tf.ones_like(s2, dtype=fd.float_type()))
 

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -77,6 +77,8 @@ class nestSource(fd.BlockModelSource):
         self.S1_noise = config.getfloat('NEST', 'S1_noise_config')
         self.S2_noise = config.getfloat('NEST', 'S2_noise_config')
 
+        self.s2_thr = config.getfloat('NEST', 's2_thr_config')
+
         self.S1_min = config.getfloat('NEST', 'S1_min_config')
         self.S1_max = config.getfloat('NEST', 'S1_max_config')
         self.S2_min = config.getfloat('NEST', 'S2_min_config')


### PR DESCRIPTION
Very minor change to add in explicit S2 threshold, separate to S2 analysis cuts. Motivated by work being done for LZ fits - just thought I would add also to the default NEST (LUX) source...