### PR TITLE
Fix max_dim_sizes bug

### DIFF
--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -266,6 +266,7 @@ class BlockModelSource(fd.Source):
         # somewhere else by accident; check none of them appear in multiple blocks
         updated_max_dim_size = []
 
+        self.max_dim_sizes = dict()
         for b in self.model_blocks:
             # Maybe someome forgot a comma in a tuple specification
             for k in collected:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -34,10 +34,6 @@ class Source:
     default_max_sigma_outer = 3
     default_max_dim_size = 70
 
-    # Capping the domain size for hidden variable dimensions. Any which aren't
-    # set will default to default_max_dim_size
-    max_dim_sizes: ty.Dict[str, int] = dict()
-
     #: Names of model functions
     model_functions: ty.Tuple[str] = tuple()
 
@@ -231,6 +227,10 @@ class Source:
         assert self.bounds_prob_outer > 0., \
             "max_sigma_outer too high!"
 
+        # Capping the domain size for hidden variable dimensions. Any which aren't
+        # set will default to default_max_dim_size
+        if not hasattr(self, 'max_dim_sizes'):
+            self.max_dim_sizes = dict()
         for dim in (self.inner_dimensions + self.bonus_dimensions + self.additional_bounds_dimensions):
             if dim not in self.max_dim_sizes:
                 self.max_dim_sizes[dim] = self.default_max_dim_size


### PR DESCRIPTION
This implements a fix to a bug that's only just come to light. `max_dim_sizes` was, before, a class attribute in `Source`. Blocks in a `BlockSource` could define a `max_dim_size` for their domains, which would then update the `max_dim_sizes` dictionary in the `Source`. The problem comes when you have 2 different types of `BlockSource` that contain blocks which set the `max_dim_size` for the same domain differently. Because `max_dim_sizes` is a class attribute of `Source`, which both `BlockSource`s inherit from, the second source will change the `max_dim_sizes` dictionary for the first source!

This fix makes it an instance attribute instead.