### PR TITLE
Rj max sigma update

### DIFF
--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -52,6 +52,7 @@ class LogLikelihood:
                 ty.Dict[str, pd.DataFrame]] = None,
             free_rates=None,
             batch_size=10,
+            max_sigma=None,
             n_trials=None,
             log_constraint=None,
             bounds_specified=True,
@@ -155,6 +156,7 @@ class LogLikelihood:
         self.sources = {
             sname: sclass(**(arguments.get(sname)),
                           data=None,
+                          max_sigma=max_sigma,
                           # The source will filter out parameters it does not
                           # take
                           fit_params=list(k for k in common_param_specs.keys()),

--- a/flamedisx/likelihood.py
+++ b/flamedisx/likelihood.py
@@ -52,8 +52,6 @@ class LogLikelihood:
                 ty.Dict[str, pd.DataFrame]] = None,
             free_rates=None,
             batch_size=10,
-            max_sigma=None,
-            max_sigma_outer=None,
             n_trials=None,
             log_constraint=None,
             bounds_specified=True,
@@ -79,14 +77,6 @@ class LogLikelihood:
         :param batch_size: Number of events to use for a computation batch.
             Higher numbers give better performance, especially for GPUs,
             at the cost of more memory
-
-        :param max_sigma: Maximum sigma to use in bounds estimation.
-            Higher numbers give better accuracy, at the cost of performance.
-            If not specified, each source will use its own default.
-
-        :param max_sigma_outer: Maximum sigma to use in bounds estimation for outer blocks.
-            Higher numbers give better accuracy, at the cost of performance.
-            If not specified, each source will use its own default.
 
         :param n_trials: Number of Monte-Carlo trials for mu estimation.
 
@@ -165,8 +155,6 @@ class LogLikelihood:
         self.sources = {
             sname: sclass(**(arguments.get(sname)),
                           data=None,
-                          max_sigma=max_sigma,
-                          max_sigma_outer=max_sigma_outer,
                           # The source will filter out parameters it does not
                           # take
                           fit_params=list(k for k in common_param_specs.keys()),

--- a/flamedisx/lxe_blocks/detection.py
+++ b/flamedisx/lxe_blocks/detection.py
@@ -97,7 +97,7 @@ class DetectPhotonsOrElectrons(fd.Block):
         for bound, sign, intify in (('min', -1, np.floor),
                                     ('max', +1, np.ceil)):
             d[self.quanta_name + 's_produced_' + bound] = intify(
-                n_prod_mle + sign * self.source.max_sigma * _std
+                n_prod_mle + sign * self.source.max_sigmas[self.quanta_name + 's_produced'] * _std
             ).clip(0, None).astype(np.int)
 
 

--- a/flamedisx/lxe_blocks/final_signals.py
+++ b/flamedisx/lxe_blocks/final_signals.py
@@ -58,7 +58,7 @@ class MakeFinalSignals(fd.Block):
             # (since fluctuations are tiny)
             # so let's just use the relative error on the MLE)
             d[self.quanta_name + 's_detected_' + bound] = intify(
-                mle + sign * self.source.max_sigma * scale
+                mle + sign * self.source.max_sigmas[self.quanta_name + 's_detected'] * scale
             ).clip(0, None).astype(np.int)
 
     def _compute(self,

--- a/flamedisx/nest/lxe_blocks/detection.py
+++ b/flamedisx/nest/lxe_blocks/detection.py
@@ -91,7 +91,8 @@ class DetectPhotonsOrElectrons(fd.Block):
                    for out_bound, support in zip(out_bounds, supports)]
 
             fd.bounds.bayes_bounds(df=d, in_dim=self.quanta_name + 's_produced',
-                                   bounds_prob=self.source.bounds_prob, bound=bound,
+                                   bounds_prob=self.source.bounds_probs[self.quanta_name + 's_produced'],
+                                   bound=bound,
                                    bound_type='binomial', supports=supports,
                                    rvs_binom=rvs, ns_binom=ns, ps_binom=ps)
 
@@ -122,7 +123,8 @@ class DetectPhotonsOrElectrons(fd.Block):
 
                 fd.bounds.bayes_bounds_priors(source=self.source, batch=batch,
                                               df=d, in_dim=self.quanta_name + 's_produced',
-                                              bounds_prob=self.source.bounds_prob, bound=bound,
+                                              bounds_prob=self.source.bounds_probs[self.quanta_name + 's_produced'],
+                                              bound=bound,
                                               bound_type='binomial', supports=supports,
                                               rvs_binom=rvs, ns_binom=ns, ps_binom=ps)
 

--- a/flamedisx/nest/lxe_blocks/double_pe.py
+++ b/flamedisx/nest/lxe_blocks/double_pe.py
@@ -56,7 +56,8 @@ class MakePhotoelectrons(fd.Block):
             rvs = [out_bound - support for out_bound, support in zip(out_bounds, supports)]
 
             fd.bounds.bayes_bounds(df=d, in_dim=self.quanta_in_name,
-                                   bounds_prob=self.source.bounds_prob, bound=bound,
+                                   bounds_prob=self.source.bounds_probs[self.quanta_in_name],
+                                   bound=bound,
                                    bound_type='binomial', supports=supports,
                                    rvs_binom=rvs, ns_binom=ns, ps_binom=ps)
 

--- a/flamedisx/nest/lxe_blocks/energy_spectrum.py
+++ b/flamedisx/nest/lxe_blocks/energy_spectrum.py
@@ -79,10 +79,10 @@ class EnergySpectrum(fd.FirstBlock):
             # We use this filtered reservoir to estimate energy bounds
             self.source.data.loc[batch * self.source.batch_size:
                                  (batch + 1) * self.source.batch_size - 1, 'energy_min'] = \
-                np.quantile(energies, self.source.bounds_prob)
+                np.quantile(energies, self.source.bounds_probs['energy'])
             self.source.data.loc[batch * self.source.batch_size:
                                  (batch + 1) * self.source.batch_size - 1, 'energy_max'] = \
-                np.quantile(energies, 1. - self.source.bounds_prob)
+                np.quantile(energies, 1. - self.source.bounds_probs['energy'])
 
     def draw_positions(self, n_events, **params):
         """Return dictionary with x, y, z, r, theta, drift_time

--- a/flamedisx/nest/lxe_blocks/final_signals.py
+++ b/flamedisx/nest/lxe_blocks/final_signals.py
@@ -52,7 +52,8 @@ class MakeFinalSignals(fd.Block):
                    for observed_signal, support in zip(observed_signals, supports)]
 
             fd.bounds.bayes_bounds(df=d, in_dim=self.signal_name + '_photoelectrons_detected',
-                                   bounds_prob=self.source.bounds_prob_outer, bound=bound,
+                                   bounds_prob=self.source.bounds_probs[self.signal_name + '_photoelectrons_detected'],
+                                   bound=bound,
                                    bound_type='normal', supports=supports,
                                    rvs_normal=rvs, mus_normal=mus, sigmas_normal=sigmas)
 

--- a/flamedisx/nest/lxe_blocks/pe_detection.py
+++ b/flamedisx/nest/lxe_blocks/pe_detection.py
@@ -51,6 +51,7 @@ class DetectS1Photoelectrons(fd.Block):
                    for out_bound, support in zip(out_bounds, supports)]
 
             fd.bounds.bayes_bounds(df=d, in_dim='s1_photoelectrons_produced',
-                                   bounds_prob=self.source.bounds_prob, bound=bound,
+                                   bounds_prob=self.source.bounds_probs['energy'],
+                                   bound=bound,
                                    bound_type='binomial', supports=supports,
                                    rvs_binom=rvs, ns_binom=ns, ps_binom=ps)

--- a/flamedisx/nest/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/nest/lxe_blocks/quanta_splitting.py
@@ -285,8 +285,8 @@ class MakePhotonsElectronsNR(fd.Block):
             nel = self.gimme_numpy('mean_yield_electron', energy)
             nq = self.gimme_numpy('mean_yield_quanta', (energy, nel))
             fano = self.gimme_numpy('fano_factor', nq)
-            nq_actual_upper = nq + np.sqrt(fano * nq) * self.source.max_sigma
-            nq_actual_lower = nq - np.sqrt(fano * nq) * self.source.max_sigma
+            nq_actual_upper = nq + np.sqrt(fano * nq) * self.source.max_sigmas['ions_produced']
+            nq_actual_lower = nq - np.sqrt(fano * nq) * self.source.max_sigmas['ions_produced']
 
             ex_ratio = self.gimme_numpy('exciton_ratio', energy)
             alpha = 1. / (1. + ex_ratio)
@@ -296,8 +296,8 @@ class MakePhotonsElectronsNR(fd.Block):
             ions_std_upper = np.sqrt(nq_actual_upper * alpha * (1 - alpha))
             ions_std_lower = np.sqrt(nq_actual_lower * alpha * (1 - alpha))
 
-            ions_produced_min = np.floor(ions_mean_lower - self.source.max_sigma * ions_std_lower).astype(int)
-            ions_produced_max = np.ceil(ions_mean_upper + self.source.max_sigma * ions_std_upper).astype(int)
+            ions_produced_min = np.floor(ions_mean_lower - self.source.max_sigmas['ions_produced'] * ions_std_lower).astype(int)
+            ions_produced_max = np.ceil(ions_mean_upper + self.source.max_sigmas['ions_produced'] * ions_std_upper).astype(int)
 
             return (ions_produced_min, ions_produced_max)
 

--- a/flamedisx/nest/lxe_blocks/quanta_splitting.py
+++ b/flamedisx/nest/lxe_blocks/quanta_splitting.py
@@ -296,8 +296,10 @@ class MakePhotonsElectronsNR(fd.Block):
             ions_std_upper = np.sqrt(nq_actual_upper * alpha * (1 - alpha))
             ions_std_lower = np.sqrt(nq_actual_lower * alpha * (1 - alpha))
 
-            ions_produced_min = np.floor(ions_mean_lower - self.source.max_sigmas['ions_produced'] * ions_std_lower).astype(int)
-            ions_produced_max = np.ceil(ions_mean_upper + self.source.max_sigmas['ions_produced'] * ions_std_upper).astype(int)
+            ions_produced_min = np.floor(ions_mean_lower - self.source.max_sigmas['ions_produced'] *
+                                         ions_std_lower).astype(int)
+            ions_produced_max = np.ceil(ions_mean_upper + self.source.max_sigmas['ions_produced'] *
+                                        ions_std_upper).astype(int)
 
             return (ions_produced_min, ions_produced_max)
 

--- a/flamedisx/nest/lxe_blocks/secondary_quanta_generation.py
+++ b/flamedisx/nest/lxe_blocks/secondary_quanta_generation.py
@@ -57,6 +57,7 @@ class MakeS2Photons(fd.Block):
                    for out_bound, support in zip(out_bounds, supports)]
 
             fd.bounds.bayes_bounds(df=d, in_dim='electrons_detected',
-                                   bounds_prob=self.source.bounds_prob, bound=bound,
+                                   bounds_prob=self.source.bounds_probs['electrons_detected'],
+                                   bound=bound,
                                    bound_type='normal', supports=supports,
                                    rvs_normal=rvs, mus_normal=mus, sigmas_normal=sigmas)

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -208,13 +208,6 @@ class Source:
         :param params: New defaults to for parameters, and new values for
         constant-valued model functions.
         """
-        self.bounds_prob = stats.norm.cdf(-3.)
-        self.bounds_prob_outer = stats.norm.cdf(-3.)
-        assert self.bounds_prob > 0., \
-            "max_sigma too high!"
-        assert self.bounds_prob_outer > 0., \
-            "max_sigma_outer too high!"
-
         # Capping the domain size for hidden variable dimensions. Any which aren't
         # set will default to default_max_dim_size
         if not hasattr(self, 'max_dim_sizes'):
@@ -230,6 +223,12 @@ class Source:
         for dim in (self.inner_dimensions + self.bonus_dimensions + self.additional_bounds_dimensions):
             if dim not in self.max_sigmas:
                 self.max_sigmas[dim] = self.default_max_sigma
+
+        self.bounds_probs = dict()
+        for dim, max_sigma in self.max_sigmas.items():
+            bounds_prob = stats.norm.cdf(-max_sigma)
+            assert bounds_prob > 0., "max_sigma too high!"
+            self.bounds_probs[dim] = bounds_prob
 
         # Check for duplicated model functions
         for attrname in ['model_functions', 'special_model_functions']:

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -189,6 +189,7 @@ class Source:
     def __init__(self,
                  data=None,
                  batch_size=10,
+                 max_sigma=None,
                  data_is_annotated=False,
                  _skip_tf_init=False,
                  _skip_bounds_computation=False,
@@ -222,7 +223,10 @@ class Source:
             self.max_sigmas = dict()
         for dim in (self.inner_dimensions + self.bonus_dimensions + self.additional_bounds_dimensions):
             if dim not in self.max_sigmas:
-                self.max_sigmas[dim] = self.default_max_sigma
+                if max_sigma is not None:
+                    self.max_sigmas[dim] = max_sigma
+                else:
+                    self.max_sigmas[dim] = self.default_max_sigma
 
         self.bounds_probs = dict()
         for dim, max_sigma in self.max_sigmas.items():


### PR DESCRIPTION
This is a small PR at the request of @plt109. It allows blocks to override the default `max_sigma` used in the bounds computation. This is especially important for Pueh's reconstruction bias block, which will use the non-integer stepping functionality. Ideally, the default sources would just move over to the Bayes bounds, negating the need for this slightly. But that's a bit more work, so hopefully this suffices as an interim solution!