### PR TITLE
Jrg spatial lz sources work in progress

### DIFF
--- a/flamedisx/block_source.py
+++ b/flamedisx/block_source.py
@@ -32,6 +32,9 @@ class Block:
     #: _calculate_dimsizes_special().
     bonus_dimensions: ty.Tuple[ty.Tuple[str, bool]] = tuple()
 
+    #: inner_dimensions which take non-integer values
+    non_integer_dimensions: ty.Tuple[str] = tuple()
+
     #: Columns that we don't want to include in the tensor of data columns
     exclude_data_tensor: ty.Tuple[str] = tuple()
 
@@ -251,6 +254,7 @@ class BlockModelSource(fd.Source):
         # Collect attributes from the different blocks in this dictionary:
         collected = {k: [] for k in (
             'dimensions',
+            'non_integer_dimensions',
             'bonus_dimensions',
             'exclude_data_tensor',
             'model_functions',
@@ -326,6 +330,8 @@ class BlockModelSource(fd.Source):
                 continue
             setattr(self, k, getattr(self, k) + tuple(set(v)))
 
+        self.non_integer_dimensions = tuple([
+            d for d in collected['non_integer_dimensions']])
         self.inner_dimensions = tuple(
             [d for d in collected['dimensions']
                 if ((d not in self.final_dimensions)

--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -96,6 +96,8 @@ class CrossInterpolatedMu(MuEstimator):
                  dtype=fd.float_type())
 
     def __call__(self, **kwargs):
+        kwargs = {param_name: kwargs[param_name] for param_name in self.bounds}
+        
         mu = self.base_mu
         for pname, v in kwargs.items():
             mu *= tfp.math.interp_regular_1d_grid(
@@ -215,7 +217,7 @@ class CombinedMu(MuEstimator):
 
         # Get base mus: mus estimated at the default values by the different
         # estimators
-        self.base_mus = [e() for e in self.estimators.values()]
+        self.base_mus = [e(**source.defaults) for e in self.estimators.values()]
         # Compute the mean. TODO: weight appropriately if n_trials varies?
         self.mean_base_mu = float(np.mean(self.base_mus))
 

--- a/flamedisx/source.py
+++ b/flamedisx/source.py
@@ -58,6 +58,9 @@ class Source:
     #: for which the domain is always a single interval of integers
     no_step_dimensions: ty.Tuple[str] = tuple()
 
+    #: inner_dimensions which take non-integer values
+    non_integer_dimensions: ty.Tuple[str] = tuple()
+
     #: Names of dimensions of hidden variables for which
     #: dimsize calculations are NOT done here (but in user-defined code)
     #: but for which we DO track _min and _dimsizes
@@ -444,6 +447,12 @@ class Source:
             steps = tf.where((ma-mi+1) > self.dimsizes[dim],
                              tf.math.ceil((ma-mi) / (self.dimsizes[dim]-1)),
                              1).numpy()  # Cover to at least the upper bound
+
+            # For non-integer dimensions, always set to max_dim_size, then step in non-integers
+            if dim in self.non_integer_dimensions:
+                self.dimsizes[dim] = self.max_dim_sizes[dim]
+                steps = (ma - mi) / (self.dimsizes[dim] - 1)
+
             # Store the steps in the dataframe
             d[dim + '_steps'] = steps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.4.1
 tqdm==4.64.1
 tensorflow==2.11.0
 tensorflow_probability==0.19.0
-iminuit==2.18.0
+iminuit==2.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.5.0
 tqdm==4.64.1
 tensorflow==2.11.0
 tensorflow_probability==0.19.0
-iminuit==2.19.0
+iminuit==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.23.5
-scipy==1.9.3
+scipy==1.10.0
 pandas==1.5.3
 multihist==0.6.5
 wimprates==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.23.5
-scipy==1.10.0
+scipy==1.10.1
 pandas==1.5.3
 multihist==0.6.5
 wimprates==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy==1.10.1
 pandas==1.5.3
 multihist==0.6.5
 wimprates==0.5.0
-tqdm==4.64.1
+tqdm==4.65.0
 tensorflow==2.11.0
 tensorflow_probability==0.19.0
 iminuit==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.5
 scipy==1.10.0
 pandas==1.5.3
 multihist==0.6.5
-wimprates==0.4.1
+wimprates==0.5.0
 tqdm==4.64.1
 tensorflow==2.11.0
 tensorflow_probability==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.23.5
 scipy==1.9.3
-pandas==1.5.2
+pandas==1.5.3
 multihist==0.6.5
 wimprates==0.4.1
 tqdm==4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ wimprates==0.5.0
 tqdm==4.65.0
 tensorflow==2.11.0
 tensorflow_probability==0.19.0
-iminuit==2.20.0
+iminuit==2.21.0


### PR DESCRIPTION
Four more nest background sources:
nest/background_sources.py:
  SpatialERSource
  SpatialXe127Source(SpatialERSource)
  SpatialNRSource
  DetNRSource(SpatialNRSource)

And two more LZ sources
lz/lz.py
  LZDetNRSource(LZSource, fd.nest.DetNRSource)
  LZSpatialXe127Source(LZSource, fd.nest.SpatialXe127Source)

Need pickles with simulated data points in lz/ with keys:
x[cm], y[cm], z[cm]/drift time[us]/drift time[ns], weight
optionally: energy_keV, spectrum_value_norm



