### PR TITLE
Fix whitespace for flake8

### DIFF
--- a/flamedisx/mu_estimation.py
+++ b/flamedisx/mu_estimation.py
@@ -97,7 +97,7 @@ class CrossInterpolatedMu(MuEstimator):
 
     def __call__(self, **kwargs):
         kwargs = {param_name: kwargs[param_name] for param_name in self.bounds}
-        
+
         mu = self.base_mu
         for pname, v in kwargs.items():
             mu *= tfp.math.interp_regular_1d_grid(


### PR DESCRIPTION
Our builds are currently failing because we missed a trailing whitespace in https://github.com/FlamTeam/flamedisx/pull/285. This removes it.