### PR TITLE
Template interpolation 

### DIFF
--- a/flamedisx/templates.py
+++ b/flamedisx/templates.py
@@ -66,7 +66,10 @@ class TemplateSource(fd.ColumnSource):
             assert len(self.final_dimensions) == 2, "Interpolation only supported for 2D histogram!"
             centers_dim_1 = 0.5 * (bin_edges[0][1:] + bin_edges[0][:-1])
             centers_dim_2 = 0.5 * (bin_edges[1][1:] + bin_edges[1][:-1])
-            self.interp_2d = interp2d(centers_dim_1, centers_dim_2, np.transpose(template))
+            self.interp_2d = interp2d(
+                centers_dim_1, centers_dim_2, 
+                np.transpose(template), 
+                kind='linear')
         else:
             self.interp_2d = None
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -48,7 +48,7 @@ def test_template_interpolation():
     data = pd.DataFrame({'x': [0.5, 1.5, 3.5], 'y': [0.5, 0.5, 2.5]})
 
     # Interpolate using flamedisx
-    s = fd.TemplateSource(mh, interp_2d=True)
+    s = fd.TemplateSource(mh, interpolate=True)
     s.set_data(data)
     dr_flamedisx = s.batched_differential_rate()
 
@@ -60,3 +60,9 @@ def test_template_interpolation():
         values=mh.histogram,
         method='linear')(z)
     assert np.allclose(dr_flamedisx, dr_itp)
+
+    # With interpolation turned off, flamedisx just looks up the diff rates
+    s = fd.TemplateSource(mh, interpolate=False)
+    s.set_data(data)
+    dr_flamedisx_noitp = s.batched_differential_rate()
+    assert np.allclose(dr_flamedisx_noitp, mh.lookup(data['x'], data['y']))

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,5 +1,7 @@
 import flamedisx as fd
 import numpy as np
+import pandas as pd
+from scipy import interpolate
 
 from multihist import Histdd
 
@@ -21,7 +23,7 @@ def test_template():
 
     # Simulate data from the template source,
     # ensuring the distribution remains similar
-    # TODO: should set seed...
+    # (Could set the seed here, but it shouldn't depend on it anyway)
     d2 = st.simulate(int(1e6))
     mh2 = Histdd(d2, axis_names=['s1', 's2'], bins=mh.bin_edges)
     assert np.abs(np.mean(
@@ -30,3 +32,31 @@ def test_template():
 
     # Total events should equal the histogram sum
     assert np.isclose(st.estimate_mu().numpy(), mh.n)
+
+
+def test_template_interpolation():
+    """Test linear interpolation of a template source"""
+
+    # Simple 2d histogram
+    mh = Histdd.from_histogram(
+        histogram=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]),
+        bin_edges=[np.array([0, 1, 2, 3, 4]), np.array([0, 1, 2, 3])],
+        axis_names=('x', 'y'),
+    )
+
+    # Events / points to interpolate
+    data = pd.DataFrame({'x': [0.5, 1.5, 3.5], 'y': [0.5, 0.5, 2.5]})
+
+    # Interpolate using flamedisx
+    s = fd.TemplateSource(mh, interp_2d=True)
+    s.set_data(data)
+    dr_flamedisx = s.batched_differential_rate()
+
+    # Interpolate using scipy
+    # RegularGridInterpolator expects (n_points, n_dims) array
+    z = np.stack([data['x'].values, data['y'].values]).T
+    dr_itp = interpolate.RegularGridInterpolator(
+        points=(mh.bin_centers(0), mh.bin_centers(1)),
+        values=mh.histogram,
+        method='linear')(z)
+    assert np.allclose(dr_flamedisx, dr_itp)


### PR DESCRIPTION
This adds to the intra-bin interpolation support for template sources that @robertsjames added in #269:
  * Support template dimensions other than 2. The `interp_2d` argument is renamed to `interpolate`.
  * Avoid the deprecated interp2d function.
  * Work correctly if the user specifies an events-per-bin template (instead of the default differential rate template).
  * Use linear interpolation instead of a higher-order bivariate spline (which interp2d defaulted to).
  * Add a unit test.

Happy to add an argument to change the interpolation method as well, though I'm not sure what higher-order interpolation would do on noisy histogram templates.
