### PR TITLE
Refactor bounds/dimension stuff into IntegratingSource

### DIFF
--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -87,9 +87,11 @@ class nestSource(fd.BlockModelSource):
     final_dimensions = ('s1', 's2')
     no_step_dimensions = ('s1_photoelectrons_produced',
                           's1_photoelectrons_detected')
-    additional_bounds_dimensions = ('energy',)
     prior_dimensions = [(('electrons_produced', 'photons_produced'),
                         ('energy', 's1_photoelectrons_detected', 's2_photoelectrons_detected'))]
+
+    def extra_needed_columns(self):
+        return super().extra_needed_columns() + ['energy_min', 'energy_max']
 
     # quanta_splitting.py
 


### PR DESCRIPTION
**What**: Move all code related to integration and summation (min/max computations, domain stepping, the various `_dimensions` attributions) into a new class named `IntegratingSource`.

**Why**:
  * Readability, this collects related code from many places into one place. 
  * Simplifies our base Source class; `ColumnSource`s, template sources, etc. do not need all of this mechanics.
  * If we want alternatives to our `BlockModelSource` (maybe auto-generating models from equations..) we can now inherit from `IntegratingSource` and keep just the parts we need.

**Related changes**
  * Removed the concept of "additional_bounds_dimensions"; all that did was include `{dimension}_min` and `{dimension}_max` in the columns to keep on the tensorflow side. This was also only used in one place, in the NEST base source for energy. We now just add `energy_min` and `energy_max` to the extra_needed_columns there.
  * Do not populate the `Source.max_dim_sizes` dictionary with defaults. It is accessed in one place, so we can use a dict.get with a default there instead. 
  * The `cap_dimsizes` method was just a few lines and it was only used in one place, so I inlined it. Also refactored the dimsize/stepping calculation a bit.
  * Removed unused argument `_skip_bounds_computation`  for `BlockModelSource._annotate`. `Source.annotate` eats this argument and does not pass it on to `_annotate`.
  * Minor stuff like adding comments or replacing "x = [] then for y in bla append f(y) to x" with `x = [f(y) for y in bla]`