### PR TITLE
Wimprates integration

### DIFF
--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -583,8 +583,6 @@ class nestWIMPSource(nestNRSource):
     # Implement using WIMPRATE -> produce 2D energy spectrum energy vs time (366)
     # Produce over a number of energies. 
     
-    print('Lorenzo Succeeded')
-    
     model_blocks = (fd_nest.WIMPEnergySpectrum,) + nestNRSource.model_blocks[1:]
 
     def __init__(self, *args, wimp_mass=40, fid_mass=1., livetime=1., **kwargs):
@@ -604,7 +602,7 @@ class nestWIMPSource(nestNRSource):
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def get_energy_hist(wimp_mass=50, min_E=1e-2, max_E=40, sigma=1, n_bins_energy=800, n_bins_time=25, modulation=False):
+    def get_energy_hist(wimp_mass=50., min_E=1e-2, max_E=40., sigma=1., n_bins_energy=800, n_bins_time=25, modulation=False):
         """
         Function to generate or obtain the energy histogram for a given WIMP mass
 

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -580,7 +580,7 @@ class nestWIMPSource(nestNRSource):
         if ('detector' not in kwargs):
             kwargs['detector'] = 'default'
 
-        self.energy_hist = pkl.load(open(os.path.join(os.path.dirname(__file__), 'wimp_spectra/WIMP_spectra.pkl'), 'rb'))[wimp_mass]
+        self.energy_hist = self.get_energy_hist(wimp_mass)
         scale = fid_mass * livetime
         self.energy_hist *= scale
 
@@ -592,6 +592,10 @@ class nestWIMPSource(nestNRSource):
 
         super().__init__(*args, **kwargs)
 
+    def get_energy_hist(self, wimp_mass):
+        _energy_hist = pkl.load(open(os.path.join(os.path.dirname(__file__), 'wimp_spectra/WIMP_spectra.pkl'), 'rb'))[wimp_mass]
+        return _energy_hist
+    
 
 @export
 class nestSolarAxionSource(nestERSource):

--- a/flamedisx/nest/lxe_sources.py
+++ b/flamedisx/nest/lxe_sources.py
@@ -8,7 +8,6 @@ import pandas as pd
 import tensorflow as tf
 
 
-
 import flamedisx as fd
 from .. import nest as fd_nest
 import multihist as mh
@@ -26,85 +25,106 @@ XENON_REF_DENSITY = 2.90
 
 
 class nestSource(fd.BlockModelSource):
-    def __init__(self, *args, detector='default', **kwargs):
-        assert detector in ('default', 'lz', 'xlzd')
+    def __init__(self, *args, detector="default", **kwargs):
+        assert detector in ("default", "lz", "xlzd")
 
         self.detector = detector
 
-        assert os.path.exists(os.path.join(
-            os.path.dirname(__file__), 'config/', detector + '.ini'))
+        assert os.path.exists(
+            os.path.join(os.path.dirname(__file__), "config/", detector + ".ini")
+        )
 
-        config = configparser.ConfigParser(inline_comment_prefixes=';')
-        config.read(os.path.join(os.path.dirname(__file__), 'config/', detector + '.ini'))
+        config = configparser.ConfigParser(inline_comment_prefixes=";")
+        config.read(
+            os.path.join(os.path.dirname(__file__), "config/", detector + ".ini")
+        )
 
         # common (known) parameters
-        self.temperature = config.getfloat('NEST', 'temperature_config')
-        self.pressure = config.getfloat('NEST', 'pressure_config')
-        self.drift_field = config.getfloat('NEST', 'drift_field_config')
-        self.gas_field = config.getfloat('NEST', 'gas_field_config')
+        self.temperature = config.getfloat("NEST", "temperature_config")
+        self.pressure = config.getfloat("NEST", "pressure_config")
+        self.drift_field = config.getfloat("NEST", "drift_field_config")
+        self.gas_field = config.getfloat("NEST", "gas_field_config")
 
         # derived (known) parameters
-        self.density = fd_nest.calculate_density(
-            self.temperature, self.pressure)
+        self.density = fd_nest.calculate_density(self.temperature, self.pressure)
         # NOTE: BE CAREFUL WITH THE BELOW, ONLY VALID NEAR VAPOUR PRESSURE!!!
         self.density_gas = fd_nest.calculate_density_gas(
-            self.temperature, self.pressure)
+            self.temperature, self.pressure
+        )
         #
         self.drift_velocity = fd_nest.calculate_drift_velocity(
-            self.drift_field, self.density, self.temperature, self.detector)
+            self.drift_field, self.density, self.temperature, self.detector
+        )
         self.Wq_keV, self.alpha = fd_nest.calculate_work(self.density)
 
         # energy_spectrum.py
-        self.radius = config.getfloat('NEST', 'radius_config')
-        self.z_topDrift = config.getfloat('NEST', 'z_topDrift_config')
-        self.z_top = self.z_topDrift - self.drift_velocity * \
-            config.getfloat('NEST', 'dt_min_config')
-        self.z_bottom = self.z_topDrift - self.drift_velocity * \
-            config.getfloat('NEST', 'dt_max_config')
+        self.radius = config.getfloat("NEST", "radius_config")
+        self.z_topDrift = config.getfloat("NEST", "z_topDrift_config")
+        self.z_top = self.z_topDrift - self.drift_velocity * config.getfloat(
+            "NEST", "dt_min_config"
+        )
+        self.z_bottom = self.z_topDrift - self.drift_velocity * config.getfloat(
+            "NEST", "dt_max_config"
+        )
 
         # detection.py / pe_detection.py / double_pe.py / final_signals.py
-        self.g1 = config.getfloat('NEST', 'g1_config')
-        self.elife = config.getfloat('NEST', 'elife_config')
-        self.extraction_eff = fd_nest.calculate_extraction_eff(self.gas_field, self.temperature)
-        self.spe_res = config.getfloat('NEST', 'spe_res_config')
-        self.spe_thr = config.getfloat('NEST', 'spe_thr_config')
-        self.spe_eff = config.getfloat('NEST', 'spe_eff_config')
-        self.num_pmts = config.getfloat('NEST', 'num_pmts_config')
-        self.double_pe_fraction = config.getfloat('NEST', 'double_pe_fraction_config')
-        self.coin_table = fd_nest.get_coin_table(config.getint('NEST', 'coin_level_config'), self.num_pmts,
-                                                 self.spe_res, self.spe_thr, self.spe_eff,
-                                                 self.double_pe_fraction)
+        self.g1 = config.getfloat("NEST", "g1_config")
+        self.elife = config.getfloat("NEST", "elife_config")
+        self.extraction_eff = fd_nest.calculate_extraction_eff(
+            self.gas_field, self.temperature
+        )
+        self.spe_res = config.getfloat("NEST", "spe_res_config")
+        self.spe_thr = config.getfloat("NEST", "spe_thr_config")
+        self.spe_eff = config.getfloat("NEST", "spe_eff_config")
+        self.num_pmts = config.getfloat("NEST", "num_pmts_config")
+        self.double_pe_fraction = config.getfloat("NEST", "double_pe_fraction_config")
+        self.coin_table = fd_nest.get_coin_table(
+            config.getint("NEST", "coin_level_config"),
+            self.num_pmts,
+            self.spe_res,
+            self.spe_thr,
+            self.spe_eff,
+            self.double_pe_fraction,
+        )
 
         # secondary_quanta_generation.py
-        self.gas_gap = config.getfloat('NEST', 'gas_gap_config')
-        self.g1_gas = config.getfloat('NEST', 'g1_gas_config')
-        self.s2Fano = config.getfloat('NEST', 's2Fano_config')
+        self.gas_gap = config.getfloat("NEST", "gas_gap_config")
+        self.g1_gas = config.getfloat("NEST", "g1_gas_config")
+        self.s2Fano = config.getfloat("NEST", "s2Fano_config")
 
         # final_signals.py
         self.s1_mean_mult = fd_nest.calculate_s1_mean_mult(self.spe_res)
-        self.s2_mean_mult = 1.
-        self.S1_noise = config.getfloat('NEST', 'S1_noise_config')
-        self.S2_noise = config.getfloat('NEST', 'S2_noise_config')
+        self.s2_mean_mult = 1.0
+        self.S1_noise = config.getfloat("NEST", "S1_noise_config")
+        self.S2_noise = config.getfloat("NEST", "S2_noise_config")
 
-        self.s2_thr = config.getfloat('NEST', 's2_thr_config')
+        self.s2_thr = config.getfloat("NEST", "s2_thr_config")
 
-        self.S1_min = config.getfloat('NEST', 'S1_min_config')
-        self.S1_max = config.getfloat('NEST', 'S1_max_config')
-        self.S2_min = config.getfloat('NEST', 'S2_min_config')
-        self.S2_max = config.getfloat('NEST', 'S2_max_config')
+        self.S1_min = config.getfloat("NEST", "S1_min_config")
+        self.S1_max = config.getfloat("NEST", "S1_max_config")
+        self.S2_min = config.getfloat("NEST", "S2_min_config")
+        self.S2_max = config.getfloat("NEST", "S2_max_config")
 
         # Useful additional parameters
-        self.g2 = fd_nest.calculate_g2(self.gas_field, self.density_gas, self.gas_gap,
-                                       self.g1_gas, self.extraction_eff)
+        self.g2 = fd_nest.calculate_g2(
+            self.gas_field,
+            self.density_gas,
+            self.gas_gap,
+            self.g1_gas,
+            self.extraction_eff,
+        )
 
         super().__init__(*args, **kwargs)
 
-    final_dimensions = ('s1', 's2')
-    no_step_dimensions = ('s1_photoelectrons_produced',
-                          's1_photoelectrons_detected')
-    additional_bounds_dimensions = ('energy',)
-    prior_dimensions = [(('electrons_produced', 'photons_produced'),
-                        ('energy', 's1_photoelectrons_detected', 's2_photoelectrons_detected'))]
+    final_dimensions = ("s1", "s2")
+    no_step_dimensions = ("s1_photoelectrons_produced", "s1_photoelectrons_detected")
+    additional_bounds_dimensions = ("energy",)
+    prior_dimensions = [
+        (
+            ("electrons_produced", "photons_produced"),
+            ("energy", "s1_photoelectrons_detected", "s2_photoelectrons_detected"),
+        )
+    ]
 
     # quanta_splitting.py
 
@@ -115,15 +135,17 @@ class nestSource(fd.BlockModelSource):
         ex_ratio = args[2]
 
         elec_frac = nel_mean / nq_mean
-        recomb_p = 1. - (ex_ratio + 1.) * elec_frac
+        recomb_p = 1.0 - (ex_ratio + 1.0) * elec_frac
 
-        return tf.where(tf.logical_or(nq_mean == 0, recomb_p < 0),
-                        tf.zeros_like(recomb_p, dtype=fd.float_type()),
-                        recomb_p)
+        return tf.where(
+            tf.logical_or(nq_mean == 0, recomb_p < 0),
+            tf.zeros_like(recomb_p, dtype=fd.float_type()),
+            recomb_p,
+        )
 
     @staticmethod
     def width_correction(skew):
-        return tf.sqrt(1. - (2. / pi) * skew * skew / (1. + skew * skew))
+        return tf.sqrt(1.0 - (2.0 / pi) * skew * skew / (1.0 + skew * skew))
 
     @staticmethod
     def mu_correction(*args):
@@ -131,7 +153,11 @@ class nestSource(fd.BlockModelSource):
         var = tf.cast(args[1], fd.float_type())
         width_corr = tf.cast(args[2], fd.float_type())
 
-        return (tf.sqrt(var) / width_corr) * (skew / tf.sqrt(1. + skew * skew)) * tf.sqrt(2. / pi)
+        return (
+            (tf.sqrt(var) / width_corr)
+            * (skew / tf.sqrt(1.0 + skew * skew))
+            * tf.sqrt(2.0 / pi)
+        )
 
     # detection.py
 
@@ -148,17 +174,25 @@ class nestSource(fd.BlockModelSource):
 
     def electron_gain_mean(self, z):
         elYield = (
-            0.137 * self.gas_field * 1e3 -
-            4.70e-18 * (N_AVAGADRO * self.density_gas / A_XENON)) \
-            * self.gas_gap * 0.1
+            (
+                0.137 * self.gas_field * 1e3
+                - 4.70e-18 * (N_AVAGADRO * self.density_gas / A_XENON)
+            )
+            * self.gas_gap
+            * 0.1
+        )
 
         return tf.cast(elYield, fd.float_type()) * tf.ones_like(z)
 
     def electron_gain_std(self, z):
         elYield = (
-            0.137 * self.gas_field * 1e3 -
-            4.70e-18 * (N_AVAGADRO * self.density_gas / A_XENON)) \
-            * self.gas_gap * 0.1
+            (
+                0.137 * self.gas_field * 1e3
+                - 4.70e-18 * (N_AVAGADRO * self.density_gas / A_XENON)
+            )
+            * self.gas_gap
+            * 0.1
+        )
 
         return tf.sqrt(self.s2Fano * elYield) * tf.ones_like(z)
 
@@ -166,15 +200,13 @@ class nestSource(fd.BlockModelSource):
 
     def photoelectron_detection_eff(self, pe_det):
         eff = tf.where(
-            self.spe_eff < 1.,
-            self.spe_eff + (1. - self.spe_eff) / (2. * self.num_pmts) * pe_det,
-            self.spe_eff)
-        eff_trunc = tf.where(
-            eff > 1.,
-            1.,
-            eff)
+            self.spe_eff < 1.0,
+            self.spe_eff + (1.0 - self.spe_eff) / (2.0 * self.num_pmts) * pe_det,
+            self.spe_eff,
+        )
+        eff_trunc = tf.where(eff > 1.0, 1.0, eff)
 
-        return 1. - (1. - eff_trunc) / (1. + self.double_pe_fraction)
+        return 1.0 - (1.0 - eff_trunc) / (1.0 + self.double_pe_fraction)
 
     # final_signals.py
 
@@ -186,25 +218,40 @@ class nestSource(fd.BlockModelSource):
 
     def s1_spe_smearing(self, n_pe):
         return tf.sqrt(
-            self.spe_res * self.spe_res * n_pe +
-            self.S1_noise * self.S1_noise * n_pe * n_pe)
+            self.spe_res * self.spe_res * n_pe
+            + self.S1_noise * self.S1_noise * n_pe * n_pe
+        )
 
     def s2_spe_smearing(self, n_pe):
         return tf.sqrt(
-            self.spe_res * self.spe_res * n_pe +
-            self.S2_noise * self.S2_noise * n_pe * n_pe)
+            self.spe_res * self.spe_res * n_pe
+            + self.S2_noise * self.S2_noise * n_pe * n_pe
+        )
 
 
 @export
 class nestERSource(nestSource):
-    def __init__(self, *args, energy_min=0.01, energy_max=10., num_energies=1000, energy_bin_edges=None, **kwargs):
-        if not hasattr(self, 'energies'):
+    def __init__(
+        self,
+        *args,
+        energy_min=0.01,
+        energy_max=10.0,
+        num_energies=1000,
+        energy_bin_edges=None,
+        **kwargs
+    ):
+        if not hasattr(self, "energies"):
             if energy_bin_edges is not None:
-                self.energies = fd.np_to_tf(0.5 * (energy_bin_edges[1:] + energy_bin_edges[:-1]))
-                self.rates_vs_energy = tf.ones(len(energy_bin_edges) - 1, fd.float_type())
+                self.energies = fd.np_to_tf(
+                    0.5 * (energy_bin_edges[1:] + energy_bin_edges[:-1])
+                )
+                self.rates_vs_energy = tf.ones(
+                    len(energy_bin_edges) - 1, fd.float_type()
+                )
             else:
-                self.energies = tf.cast(tf.linspace(energy_min, energy_max, num_energies),
-                                        fd.float_type())
+                self.energies = tf.cast(
+                    tf.linspace(energy_min, energy_max, num_energies), fd.float_type()
+                )
                 self.rates_vs_energy = tf.ones(num_energies, fd.float_type())
         super().__init__(*args, **kwargs)
 
@@ -219,7 +266,8 @@ class nestERSource(nestSource):
         fd_nest.MakeS2Photons,
         fd_nest.DetectS2Photons,
         fd_nest.MakeS2Photoelectrons,
-        fd_nest.MakeS2)
+        fd_nest.MakeS2,
+    )
 
     # quanta_splitting.py
 
@@ -228,33 +276,84 @@ class nestERSource(nestSource):
 
         Nq = energy * 1e3 / Wq_eV
 
-        m1 = tf.cast(30.66 + (6.1978 - 30.66) / pow(1. + pow(self.drift_field / 73.855, 2.0318), 0.41883),
-                     fd.float_type())
-        m5 = tf.cast(Nq / energy / (1 + self.alpha * tf.math.erf(0.05 * energy)), fd.float_type()) - m1
-        m10 = tf.cast((0.0508273937 + (0.1166087199 - 0.0508273937) /
-                      (1 + pow(self.drift_field / 1.39260460e+02, -0.65763592))),
-                      fd.float_type())
+        m1 = tf.cast(
+            30.66
+            + (6.1978 - 30.66)
+            / pow(1.0 + pow(self.drift_field / 73.855, 2.0318), 0.41883),
+            fd.float_type(),
+        )
+        m5 = (
+            tf.cast(
+                Nq / energy / (1 + self.alpha * tf.math.erf(0.05 * energy)),
+                fd.float_type(),
+            )
+            - m1
+        )
+        m10 = tf.cast(
+            (
+                0.0508273937
+                + (0.1166087199 - 0.0508273937)
+                / (1 + pow(self.drift_field / 1.39260460e02, -0.65763592))
+            ),
+            fd.float_type(),
+        )
 
-        Qy = m1 + (77.2931084 - m1) / pow((1. + pow(energy / (fd.tf_log10(tf.cast(self.drift_field, fd.float_type())) *
-                                                    0.13946236 + 0.52561312),
-                                                    1.82217496 + (2.82528809 - 1.82217496) /
-                                                    (1 + pow(self.drift_field / 144.65029656, -2.80532006)))),
-                                          0.3344049589) + \
-            m5 + (0. - m5) / pow((1. + pow(energy / (7.02921301 + (98.27936794 - 7.02921301) /
-                                 (1. + pow(self.drift_field / 256.48156448, 1.29119251))), 4.285781736)), m10)
+        Qy = (
+            m1
+            + (77.2931084 - m1)
+            / pow(
+                (
+                    1.0
+                    + pow(
+                        energy
+                        / (
+                            fd.tf_log10(tf.cast(self.drift_field, fd.float_type()))
+                            * 0.13946236
+                            + 0.52561312
+                        ),
+                        1.82217496
+                        + (2.82528809 - 1.82217496)
+                        / (1 + pow(self.drift_field / 144.65029656, -2.80532006)),
+                    )
+                ),
+                0.3344049589,
+            )
+            + m5
+            + (0.0 - m5)
+            / pow(
+                (
+                    1.0
+                    + pow(
+                        energy
+                        / (
+                            7.02921301
+                            + (98.27936794 - 7.02921301)
+                            / (1.0 + pow(self.drift_field / 256.48156448, 1.29119251))
+                        ),
+                        4.285781736,
+                    )
+                ),
+                m10,
+            )
+        )
 
-        coeff_TI = tf.cast(pow(1. / XENON_REF_DENSITY, 0.3), fd.float_type())
-        coeff_Ni = tf.cast(pow(1. / XENON_REF_DENSITY, 1.4), fd.float_type())
-        coeff_OL = tf.cast(pow(1. / XENON_REF_DENSITY, -1.7) /
-                           fd.tf_log10(1. + coeff_TI * coeff_Ni * pow(XENON_REF_DENSITY, 1.7)), fd.float_type())
+        coeff_TI = tf.cast(pow(1.0 / XENON_REF_DENSITY, 0.3), fd.float_type())
+        coeff_Ni = tf.cast(pow(1.0 / XENON_REF_DENSITY, 1.4), fd.float_type())
+        coeff_OL = tf.cast(
+            pow(1.0 / XENON_REF_DENSITY, -1.7)
+            / fd.tf_log10(1.0 + coeff_TI * coeff_Ni * pow(XENON_REF_DENSITY, 1.7)),
+            fd.float_type(),
+        )
 
-        Qy *= coeff_OL * fd.tf_log10(1. + coeff_TI * coeff_Ni * pow(self.density, 1.7)) * pow(self.density, -1.7)
+        Qy *= (
+            coeff_OL
+            * fd.tf_log10(1.0 + coeff_TI * coeff_Ni * pow(self.density, 1.7))
+            * pow(self.density, -1.7)
+        )
 
         nel_temp = Qy * energy
         # Don't let number of electrons go negative
-        nel = tf.where(nel_temp < 0,
-                       0 * nel_temp,
-                       nel_temp)
+        nel = tf.where(nel_temp < 0, 0 * nel_temp, nel_temp)
 
         return nel
 
@@ -266,9 +365,7 @@ class nestERSource(nestSource):
 
         nph_temp = nq_temp - nel_mean
         # Don't let number of photons go negative
-        nph = tf.where(nph_temp < 0,
-                       0 * nph_temp,
-                       nph_temp)
+        nph = tf.where(nph_temp < 0, 0 * nph_temp, nph_temp)
 
         nq = nel_mean + nph
 
@@ -276,7 +373,12 @@ class nestERSource(nestSource):
 
     def fano_factor(self, nq_mean):
         er_free_a = 0.0015
-        Fano = 0.12707 - 0.029623 * self.density - 0.0057042 * pow(self.density, 2.) + 0.0015957 * pow(self.density, 3.)
+        Fano = (
+            0.12707
+            - 0.029623 * self.density
+            - 0.0057042 * pow(self.density, 2.0)
+            + 0.0015957 * pow(self.density, 3.0)
+        )
 
         return Fano + er_free_a * tf.sqrt(nq_mean) * pow(self.drift_field, 0.5)
 
@@ -287,30 +389,42 @@ class nestERSource(nestSource):
         energy = self.Wq_keV * nq_mean
 
         alpha0 = tf.cast(1.39, fd.float_type())
-        cc0 = tf.cast(4., fd.float_type())
+        cc0 = tf.cast(4.0, fd.float_type())
         cc1 = tf.cast(22.1, fd.float_type())
         E0 = tf.cast(7.7, fd.float_type())
-        E1 = tf.cast(54., fd.float_type())
+        E1 = tf.cast(54.0, fd.float_type())
         E2 = tf.cast(26.7, fd.float_type())
         E3 = tf.cast(6.4, fd.float_type())
-        F0 = tf.cast(225., fd.float_type())
-        F1 = tf.cast(71., fd.float_type())
+        F0 = tf.cast(225.0, fd.float_type())
+        F1 = tf.cast(71.0, fd.float_type())
 
-        skew = 1. / (1. + tf.exp((energy - E2) / E3)) * \
-            (alpha0 + cc0 * tf.exp(-1. * self.drift_field / F0) * (1. - tf.exp(-1. * energy / E0))) + \
-            1. / (1. + tf.exp(-1. * (energy - E2) / E3)) * cc1 * tf.exp(-1. * energy / E1) * \
-            tf.exp(-1. * tf.sqrt(self.drift_field) / tf.sqrt(F1))
+        skew = 1.0 / (1.0 + tf.exp((energy - E2) / E3)) * (
+            alpha0
+            + cc0
+            * tf.exp(-1.0 * self.drift_field / F0)
+            * (1.0 - tf.exp(-1.0 * energy / E0))
+        ) + 1.0 / (1.0 + tf.exp(-1.0 * (energy - E2) / E3)) * cc1 * tf.exp(
+            -1.0 * energy / E1
+        ) * tf.exp(
+            -1.0 * tf.sqrt(self.drift_field) / tf.sqrt(F1)
+        )
 
-        mask_quanta = tf.less(nq_mean, 10000*tf.ones_like(nq_mean))
-        mask_field_low = tf.greater(self.drift_field*tf.ones_like(nq_mean), 50.*tf.ones_like(nq_mean))
-        mask_field_high = tf.less(self.drift_field*tf.ones_like(nq_mean), 2000.*tf.ones_like(nq_mean))
+        mask_quanta = tf.less(nq_mean, 10000 * tf.ones_like(nq_mean))
+        mask_field_low = tf.greater(
+            self.drift_field * tf.ones_like(nq_mean), 50.0 * tf.ones_like(nq_mean)
+        )
+        mask_field_high = tf.less(
+            self.drift_field * tf.ones_like(nq_mean), 2000.0 * tf.ones_like(nq_mean)
+        )
 
-        mask_product = tf.logical_and(mask_quanta, tf.logical_and(mask_field_low, mask_field_high))
+        mask_product = tf.logical_and(
+            mask_quanta, tf.logical_and(mask_field_low, mask_field_high)
+        )
 
         skewness = tf.ones_like(nq_mean, dtype=fd.float_type()) * skew
         skewness_masked = tf.multiply(skewness, tf.cast(mask_product, fd.float_type()))
 
-        if self.detector == 'lz':
+        if self.detector == "lz":
             skewness_masked = tf.zeros_like(nq_mean, dtype=fd.float_type())
 
         return skewness_masked
@@ -321,7 +435,7 @@ class nestERSource(nestSource):
         recomb_p = args[2]
         ni = args[3]
 
-        if self.detector == 'lz':
+        if self.detector == "lz":
             er_free_b = 0.046452
         else:
             er_free_b = 0.0553
@@ -330,36 +444,60 @@ class nestERSource(nestSource):
         er_free_e = -0.2
 
         elec_frac = nel_mean / nq_mean
-        ampl = tf.cast(0.086036 + (er_free_b - 0.086036) /
-                       pow((1. + pow(self.drift_field / 295.2, 251.6)), 0.0069114),
-                       fd.float_type())
+        ampl = tf.cast(
+            0.086036
+            + (er_free_b - 0.086036)
+            / pow((1.0 + pow(self.drift_field / 295.2, 251.6)), 0.0069114),
+            fd.float_type(),
+        )
         wide = er_free_c
         cntr = er_free_d
         skew = er_free_e
 
-        mode = cntr + 2. / (tf.sqrt(2. * pi)) * skew * wide / tf.sqrt(1. + skew * skew)
-        norm = 1. / (tf.exp(-0.5 * pow(mode - cntr, 2.) / (wide * wide)) *
-                     (1. + tf.math.erf(skew * (mode - cntr) / (wide * tf.sqrt(2.)))))
+        mode = cntr + 2.0 / (tf.sqrt(2.0 * pi)) * skew * wide / tf.sqrt(
+            1.0 + skew * skew
+        )
+        norm = 1.0 / (
+            tf.exp(-0.5 * pow(mode - cntr, 2.0) / (wide * wide))
+            * (1.0 + tf.math.erf(skew * (mode - cntr) / (wide * tf.sqrt(2.0))))
+        )
 
-        omega = norm * ampl * tf.exp(-0.5 * pow(elec_frac - cntr, 2.) / (wide * wide)) * \
-            (1. + tf.math.erf(skew * (elec_frac - cntr) / (wide * tf.sqrt(2.))))
-        omega = tf.where(nq_mean == 0,
-                         tf.zeros_like(omega, dtype=fd.float_type()),
-                         omega)
+        omega = (
+            norm
+            * ampl
+            * tf.exp(-0.5 * pow(elec_frac - cntr, 2.0) / (wide * wide))
+            * (1.0 + tf.math.erf(skew * (elec_frac - cntr) / (wide * tf.sqrt(2.0))))
+        )
+        omega = tf.where(
+            nq_mean == 0, tf.zeros_like(omega, dtype=fd.float_type()), omega
+        )
 
-        return recomb_p * (1. - recomb_p) * ni + omega * omega * ni * ni
+        return recomb_p * (1.0 - recomb_p) * ni + omega * omega * ni * ni
 
 
 @export
 class nestNRSource(nestSource):
-    def __init__(self, *args, energy_min=0.01, energy_max=10., num_energies=1000, energy_bin_edges=None, **kwargs):
-        if not hasattr(self, 'energies'):
+    def __init__(
+        self,
+        *args,
+        energy_min=0.01,
+        energy_max=10.0,
+        num_energies=1000,
+        energy_bin_edges=None,
+        **kwargs
+    ):
+        if not hasattr(self, "energies"):
             if energy_bin_edges is not None:
-                self.energies = fd.np_to_tf(0.5 * (energy_bin_edges[1:] + energy_bin_edges[:-1]))
-                self.rates_vs_energy = tf.ones(len(energy_bin_edges) - 1, fd.float_type())
+                self.energies = fd.np_to_tf(
+                    0.5 * (energy_bin_edges[1:] + energy_bin_edges[:-1])
+                )
+                self.rates_vs_energy = tf.ones(
+                    len(energy_bin_edges) - 1, fd.float_type()
+                )
             else:
-                self.energies = tf.cast(tf.linspace(energy_min, energy_max, num_energies),
-                                        fd.float_type())
+                self.energies = tf.cast(
+                    tf.linspace(energy_min, energy_max, num_energies), fd.float_type()
+                )
                 self.rates_vs_energy = tf.ones(num_energies, fd.float_type())
         super().__init__(*args, **kwargs)
 
@@ -374,69 +512,78 @@ class nestNRSource(nestSource):
         fd_nest.MakeS2Photons,
         fd_nest.DetectS2Photons,
         fd_nest.MakeS2Photoelectrons,
-        fd_nest.MakeS2)
+        fd_nest.MakeS2,
+    )
 
     # quanta_splitting.py
 
     def mean_yields(self, energy):
-        nr_nuis_a = 11.
+        nr_nuis_a = 11.0
         nr_nuis_b = 1.1
         nr_nuis_c = 0.0480
         nr_nuis_d = -0.0533
         nr_nuis_e = 12.6
         nr_nuis_f = 0.3
-        nr_nuis_g = 2.
+        nr_nuis_g = 2.0
         nr_nuis_h = 0.3
         nr_nuis_i = 2
         nr_nuis_j = 0.5
-        nr_nuis_k = 1.
-        nr_nuis_l = 1.
+        nr_nuis_k = 1.0
+        nr_nuis_l = 1.0
 
-        TIB = nr_nuis_c * pow(self.drift_field, nr_nuis_d) * pow(self.density / XENON_REF_DENSITY, 0.3)
-        Qy = 1. / (TIB * pow(energy + nr_nuis_e, nr_nuis_j))
-        Qy *= (1. - (1. / pow(1. + pow(energy / nr_nuis_f, nr_nuis_g), nr_nuis_k)))
+        TIB = (
+            nr_nuis_c
+            * pow(self.drift_field, nr_nuis_d)
+            * pow(self.density / XENON_REF_DENSITY, 0.3)
+        )
+        Qy = 1.0 / (TIB * pow(energy + nr_nuis_e, nr_nuis_j))
+        Qy *= 1.0 - (1.0 / pow(1.0 + pow(energy / nr_nuis_f, nr_nuis_g), nr_nuis_k))
 
         nel_temp = Qy * energy
         # Don't let number of electrons go negative
-        nel = tf.where(nel_temp < 0,
-                       0 * nel_temp,
-                       nel_temp)
+        nel = tf.where(nel_temp < 0, 0 * nel_temp, nel_temp)
 
         nq_temp = nr_nuis_a * pow(energy, nr_nuis_b)
 
-        nph_temp = (nq_temp - nel) * (1. - (1. / pow(1. + pow(energy / nr_nuis_h, nr_nuis_i), nr_nuis_l)))
+        nph_temp = (nq_temp - nel) * (
+            1.0 - (1.0 / pow(1.0 + pow(energy / nr_nuis_h, nr_nuis_i), nr_nuis_l))
+        )
         # Don't let number of photons go negative
-        nph = tf.where(nph_temp < 0,
-                       0 * nph_temp,
-                       nph_temp)
+        nph = tf.where(nph_temp < 0, 0 * nph_temp, nph_temp)
 
         nq = nel + nph
 
-        ni = (4. / TIB) * (tf.exp(nel * TIB / 4.) - 1.)
+        ni = (4.0 / TIB) * (tf.exp(nel * TIB / 4.0) - 1.0)
 
         nex = nq - ni
 
         ex_ratio = tf.cast(nex / ni, fd.float_type())
 
-        ex_ratio = tf.where(tf.logical_and(ex_ratio < self.alpha, energy > 100.),
-                            self.alpha * tf.ones_like(ex_ratio, dtype=fd.float_type()),
-                            ex_ratio)
-        ex_ratio = tf.where(tf.logical_and(ex_ratio > 1., energy < 1.),
-                            tf.ones_like(ex_ratio, dtype=fd.float_type()),
-                            ex_ratio)
-        ex_ratio = tf.where(tf.math.is_nan(ex_ratio),
-                            tf.zeros_like(ex_ratio, dtype=fd.float_type()),
-                            ex_ratio)
+        ex_ratio = tf.where(
+            tf.logical_and(ex_ratio < self.alpha, energy > 100.0),
+            self.alpha * tf.ones_like(ex_ratio, dtype=fd.float_type()),
+            ex_ratio,
+        )
+        ex_ratio = tf.where(
+            tf.logical_and(ex_ratio > 1.0, energy < 1.0),
+            tf.ones_like(ex_ratio, dtype=fd.float_type()),
+            ex_ratio,
+        )
+        ex_ratio = tf.where(
+            tf.math.is_nan(ex_ratio),
+            tf.zeros_like(ex_ratio, dtype=fd.float_type()),
+            ex_ratio,
+        )
 
         return nel, nq, ex_ratio
 
     def yield_fano(self, nq_mean):
-        if self.detector == 'lz':
+        if self.detector == "lz":
             nr_free_a = 0.4
             nr_free_b = 0.4
         else:
-            nr_free_a = 1.
-            nr_free_b = 1.
+            nr_free_a = 1.0
+            nr_free_b = 1.0
 
         ni_fano = tf.ones_like(nq_mean, dtype=fd.float_type()) * nr_free_a
         nex_fano = tf.ones_like(nq_mean, dtype=fd.float_type()) * nr_free_b
@@ -459,7 +606,7 @@ class nestNRSource(nestSource):
         recomb_p = args[2]
         ni = args[3]
 
-        if self.detector == 'lz':
+        if self.detector == "lz":
             nr_free_c = 0.04
         else:
             nr_free_c = 0.1
@@ -468,12 +615,16 @@ class nestNRSource(nestSource):
 
         elec_frac = nel_mean / nq_mean
 
-        omega = nr_free_c * tf.exp(-0.5 * pow(elec_frac - nr_free_d, 2.) / (nr_free_e * nr_free_e))
-        omega = tf.where(nq_mean == 0,
-                         tf.zeros_like(omega, dtype=fd.float_type()),
-                         tf.cast(omega, dtype=fd.float_type()))
+        omega = nr_free_c * tf.exp(
+            -0.5 * pow(elec_frac - nr_free_d, 2.0) / (nr_free_e * nr_free_e)
+        )
+        omega = tf.where(
+            nq_mean == 0,
+            tf.zeros_like(omega, dtype=fd.float_type()),
+            tf.cast(omega, dtype=fd.float_type()),
+        )
 
-        return recomb_p * (1. - recomb_p) * ni + omega * omega * ni * ni
+        return recomb_p * (1.0 - recomb_p) * ni + omega * omega * ni * ni
 
 
 @export
@@ -483,25 +634,34 @@ class nestGammaSource(nestERSource):
 
     def mean_yield_electron(self, energy):
         Wq_eV = self.Wq_keV * 1e3
-        m3 = 2.
-        m4 = 2.
-        m6 = 0.
+        m3 = 2.0
+        m4 = 2.0
+        m6 = 0.0
 
-        m1 = 33.951 + (3.3284 - 33.951) / (1. + pow(self.drift_field / 165.34, .72665))
+        m1 = 33.951 + (3.3284 - 33.951) / (
+            1.0 + pow(self.drift_field / 165.34, 0.72665)
+        )
         m2 = 1000 / Wq_eV
-        m5 = 23.156 + (10.737 - 23.156) / (1. + pow(self.drift_field / 34.195, .87459))
-        densCorr = 240720. / pow(self.density, 8.2076)
-        m7 = 66.825 + (829.25 - 66.825) / (1. + pow(self.drift_field / densCorr, .83344))
+        m5 = 23.156 + (10.737 - 23.156) / (
+            1.0 + pow(self.drift_field / 34.195, 0.87459)
+        )
+        densCorr = 240720.0 / pow(self.density, 8.2076)
+        m7 = 66.825 + (829.25 - 66.825) / (
+            1.0 + pow(self.drift_field / densCorr, 0.83344)
+        )
 
-        m8 = 2.
+        m8 = 2.0
 
-        Qy = m1 + (m2 - m1) / (1. + pow(energy / m3, m4)) + m5 + (m6 - m5) / (1. + pow(energy / m7, m8))
+        Qy = (
+            m1
+            + (m2 - m1) / (1.0 + pow(energy / m3, m4))
+            + m5
+            + (m6 - m5) / (1.0 + pow(energy / m7, m8))
+        )
 
         nel_temp = Qy * energy
         # Don't let number of electrons go negative
-        nel = tf.where(nel_temp < 0,
-                       0 * nel_temp,
-                       nel_temp)
+        nel = tf.where(nel_temp < 0, 0 * nel_temp, nel_temp)
 
         return nel
 
@@ -519,90 +679,148 @@ class nestERGammaWeightedSource(nestERSource):
         weight_param_e = 421.15
         weight_param_f = 3.27
 
-        weightG = tf.cast(weight_param_a + weight_param_b * tf.math.erf(weight_param_c *
-                          (tf.math.log(energy) + weight_param_d)) *
-                          (1. - (1. / (1. + pow(self.drift_field / weight_param_e, weight_param_f)))),
-                          fd.float_type())
-        weightB = tf.cast(1. - weightG, fd.float_type())
+        weightG = tf.cast(
+            weight_param_a
+            + weight_param_b
+            * tf.math.erf(weight_param_c * (tf.math.log(energy) + weight_param_d))
+            * (
+                1.0
+                - (1.0 / (1.0 + pow(self.drift_field / weight_param_e, weight_param_f)))
+            ),
+            fd.float_type(),
+        )
+        weightB = tf.cast(1.0 - weightG, fd.float_type())
 
-        nel_gamma = tf.cast(nestGammaSource.mean_yield_electron(self, energy), fd.float_type())
-        nel_beta = tf.cast(nestERSource.mean_yield_electron(self, energy), fd.float_type())
+        nel_gamma = tf.cast(
+            nestGammaSource.mean_yield_electron(self, energy), fd.float_type()
+        )
+        nel_beta = tf.cast(
+            nestERSource.mean_yield_electron(self, energy), fd.float_type()
+        )
 
         return nel_gamma * weightG + nel_beta * weightB
 
 
 @export
 class nestFasterERSource(nestERSource):
-    model_blocks = (fd_nest.FixedShapeEnergySpectrumFaster,) + nestERSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.FixedShapeEnergySpectrumFaster,
+    ) + nestERSource.model_blocks[1:]
 
 
 @export
 class nestSpatialRateERSource(nestERSource):
-    model_blocks = (fd_nest.SpatialRateEnergySpectrumER,) + nestERSource.model_blocks[1:]
+    model_blocks = (fd_nest.SpatialRateEnergySpectrumER,) + nestERSource.model_blocks[
+        1:
+    ]
 
 
 @export
 class nestSpatialRateNRSource(nestNRSource):
-    model_blocks = (fd_nest.SpatialRateEnergySpectrumNR,) + nestNRSource.model_blocks[1:]
+    model_blocks = (fd_nest.SpatialRateEnergySpectrumNR,) + nestNRSource.model_blocks[
+        1:
+    ]
 
 
 @export
 class nestTemporalRateDecayERSource(nestERSource):
-    model_blocks = (fd_nest.TemporalRateEnergySpectrumDecayER,) + nestERSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.TemporalRateEnergySpectrumDecayER,
+    ) + nestERSource.model_blocks[1:]
 
 
 @export
 class nestTemporalRateDecayNRSource(nestNRSource):
-    model_blocks = (fd_nest.TemporalRateEnergySpectrumDecayNR,) + nestNRSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.TemporalRateEnergySpectrumDecayNR,
+    ) + nestNRSource.model_blocks[1:]
 
 
 @export
 class nestSpatialTemporalRateDecayERSource(nestERSource):
-    model_blocks = (fd_nest.SpatialTemporalRateEnergySpectrumDecayER,) + nestERSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.SpatialTemporalRateEnergySpectrumDecayER,
+    ) + nestERSource.model_blocks[1:]
 
 
 @export
 class nestSpatialTemporalRateDecayNRSource(nestNRSource):
-    model_blocks = (fd_nest.SpatialTemporalRateEnergySpectrumDecayNR,) + nestNRSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.SpatialTemporalRateEnergySpectrumDecayNR,
+    ) + nestNRSource.model_blocks[1:]
 
 
 @export
 class nestTemporalRateOscillationERSource(nestERSource):
-    model_blocks = (fd_nest.TemporalRateEnergySpectrumOscillationER,) + nestERSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.TemporalRateEnergySpectrumOscillationER,
+    ) + nestERSource.model_blocks[1:]
 
 
 @export
 class nestTemporalRateOscillationNRSource(nestNRSource):
-    model_blocks = (fd_nest.TemporalRateEnergySpectrumOscillationNR,) + nestNRSource.model_blocks[1:]
+    model_blocks = (
+        fd_nest.TemporalRateEnergySpectrumOscillationNR,
+    ) + nestNRSource.model_blocks[1:]
 
 
 @export
 class nestWIMPSource(nestNRSource):
-    
+
     # WIMP energy spectrum
     # Implement using WIMPRATE -> produce 2D energy spectrum energy vs time (366)
-    # Produce over a number of energies. 
-    
+    # Produce over a number of energies.
+
     model_blocks = (fd_nest.WIMPEnergySpectrum,) + nestNRSource.model_blocks[1:]
 
-    def __init__(self, *args, wimp_mass=40, fid_mass=1., livetime=1., **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'default'
+    def __init__(
+        self,
+        *args,
+        wimp_mass=50.0,
+        min_E=1e-2,
+        max_E=40.0,
+        sigma=1.0,
+        n_bins_energy=800,
+        n_bins_time=25,
+        modulation=False,
+        fid_mass=1.0,
+        livetime=1.0,
+        detector="default",
+        **kwargs
+    ):
 
-        self.energy_hist = self.get_energy_hist(wimp_mass)
+        self.energy_hist = self.get_energy_hist(
+            wimp_mass=wimp_mass,
+            min_E=min_E,
+            max_E=max_E,
+            sigma=sigma,
+            n_bins_energy=n_bins_energy,
+            n_bins_time=n_bins_time,
+            modulation=modulation,
+        )
         scale = fid_mass * livetime
         self.energy_hist *= scale
 
         self.n_time_bins = len(self.energy_hist.bin_edges[0])
-        e_centers = fd_nest.WIMPEnergySpectrum.bin_centers(self.energy_hist.bin_edges[1])
+        e_centers = fd_nest.WIMPEnergySpectrum.bin_centers(
+            self.energy_hist.bin_edges[1]
+        )
         self.energies = fd.np_to_tf(e_centers)
 
-        self.array_columns = (('energy_spectrum', len(e_centers)),)
+        self.array_columns = (("energy_spectrum", len(e_centers)),)
 
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def get_energy_hist(wimp_mass=50., min_E=1e-2, max_E=40., sigma=1., n_bins_energy=800, n_bins_time=25, modulation=False):
+    def get_energy_hist(
+        wimp_mass=50.0,
+        min_E=1e-2,
+        max_E=40.0,
+        sigma=1.0,
+        n_bins_energy=800,
+        n_bins_time=25,
+        modulation=False,
+    ):
         """
         Function to generate or obtain the energy histogram for a given WIMP mass
 
@@ -612,14 +830,14 @@ class nestWIMPSource(nestNRSource):
             Mass of the WIMP in GeV/c^2
         min_E : float
             Minimum energy of the histogram in keV
-        max_E : float   
+        max_E : float
             Maximum energy of the histogram in keV
         sigma : float
             Cross-section of the WIMP in pb
         n_bins_energy : int
             Number of bins for the energy histogram
         n_bins_time : int
-            Number of bins for the time histogram. 
+            Number of bins for the time histogram.
             To total timespan to bin is currently hardcoded to 1 year
         modulation : bool
             Flag to enable/disable modulation
@@ -635,24 +853,31 @@ class nestWIMPSource(nestNRSource):
             modulation_scaling = np.repeat(1 / n_bins_time, n_bins_time)
 
         rates = rate_wimp_std(energy_values, wimp_mass, sigma)
-        RATES = np.array([
-            modulation_scaling[i] * rates for i in range(n_bins_time)
-        ])
-    
-        hist = mh.Histdd.from_histogram(RATES, [time_bin_edges, energy_bin_edges])
+        RATES = np.array([modulation_scaling[i] * rates for i in range(n_bins_time)])
+
+        hist = mh.Histdd.from_histogram(
+            RATES, [time_bin_edges, energy_bin_edges], axis_names=("time", "energy")
+        )
 
         return hist
-    
+
+
 @export
 class nestSolarAxionSource(nestERSource):
-    def __init__(self, *args, fid_mass=1., livetime=1., **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'default'
+    def __init__(self, *args, fid_mass=1.0, livetime=1.0, **kwargs):
+        if "detector" not in kwargs:
+            kwargs["detector"] = "default"
 
-        df_solar_axion = pd.read_pickle(os.path.join(os.path.dirname(__file__), 'solar_axion_spectrum.pkl'))
+        df_solar_axion = pd.read_pickle(
+            os.path.join(os.path.dirname(__file__), "solar_axion_spectrum.pkl")
+        )
 
-        self.energies = tf.convert_to_tensor(df_solar_axion['energy_keV'].values, dtype=fd.float_type())
+        self.energies = tf.convert_to_tensor(
+            df_solar_axion["energy_keV"].values, dtype=fd.float_type()
+        )
         scale = fid_mass * livetime * 1.577
-        self.rates_vs_energy = tf.convert_to_tensor(df_solar_axion['spectrum_value_norm'].values * scale, dtype=fd.float_type())
+        self.rates_vs_energy = tf.convert_to_tensor(
+            df_solar_axion["spectrum_value_norm"].values * scale, dtype=fd.float_type()
+        )
 
         super().__init__(*args, **kwargs)

--- a/flamedisx/utils.py
+++ b/flamedisx/utils.py
@@ -294,3 +294,25 @@ def filter_kwargs(func, kwargs):
         # if func accepts wildcard kwargs, return all
         return kwargs
     return {k: v for k, v in kwargs.items() if k in params}
+
+
+@export
+def relative_modulation(n_bins=25, v_sun=220, v_earth=30):
+    """
+    Calculate the modulation due to the Earth's orbit around the Sun 
+    WARNING: currently it only works if the total bins span 1 year
+
+    Parameters:
+    vsun : float
+        Speed of the Sun in km/s
+    vearth : float
+        Speed of the Earth in km/s
+    """
+
+    relative_velocity = v_sun - v_earth*np.cos(2*np.pi*(np.arange(0, n_bins)/n_bins))
+    mean = np.mean(relative_velocity)
+    relative_velocity -= mean
+    relative_velocity /= mean
+    relative_velocity += 1
+
+    return relative_velocity

--- a/flamedisx/xlzd/xlzd.py
+++ b/flamedisx/xlzd/xlzd.py
@@ -1,6 +1,7 @@
 """Toy XLZD detector implementation
 
 """
+
 import numpy as np
 import tensorflow as tf
 
@@ -20,41 +21,66 @@ export, __all__ = fd.exporter()
 
 
 class XLZDSource:
-    def __init__(self, *args,
-                 drift_field_V_cm=100., gas_field_kV_cm=8., elife_ns=10000e3, g1=0.27,
-                 ignore_maps_acc=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        drift_field_V_cm=100.0,
+        gas_field_kV_cm=8.0,
+        elife_ns=10000e3,
+        g1=0.27,
+        ignore_maps_acc=False,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
 
-        assert kwargs['detector'] in ('xlzd',)
-        assert kwargs['configuration'] in ('80t', '60t', '40t')
+        assert kwargs["detector"] in ("xlzd",)
+        assert kwargs["configuration"] in ("80t", "60t", "40t")
 
-        assert os.path.exists(os.path.join(
-            os.path.dirname(__file__), '../nest/config/', kwargs['detector'] + '.ini'))
+        assert os.path.exists(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../nest/config/",
+                kwargs["detector"] + ".ini",
+            )
+        )
 
-        config = configparser.ConfigParser(inline_comment_prefixes=';')
-        config.read(os.path.join(os.path.dirname(__file__), '../nest/config/',
-                                 kwargs['detector'] + '.ini'))
+        config = configparser.ConfigParser(inline_comment_prefixes=";")
+        config.read(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../nest/config/",
+                kwargs["detector"] + ".ini",
+            )
+        )
 
         if ignore_maps_acc:
             self.ignore_acceptances = True
 
-        self.radius = config.getfloat(kwargs['configuration'], 'radius_config')
-        self.z_topDrift = config.getfloat(kwargs['configuration'], 'z_topDrift_config')
-        self.z_top = config.getfloat(kwargs['configuration'], 'z_top_config')
-        self.z_bottom = config.getfloat(kwargs['configuration'], 'z_bottom_config')
+        self.radius = config.getfloat(kwargs["configuration"], "radius_config")
+        self.z_topDrift = config.getfloat(kwargs["configuration"], "z_topDrift_config")
+        self.z_top = config.getfloat(kwargs["configuration"], "z_top_config")
+        self.z_bottom = config.getfloat(kwargs["configuration"], "z_bottom_config")
 
-        self.configuration = kwargs['configuration']
+        self.configuration = kwargs["configuration"]
 
         self.drift_field = drift_field_V_cm
         self.gas_field = gas_field_kV_cm
         self.elife = elife_ns
-        self.g1 = g1 # this represents PMT QE
+        self.g1 = g1  # this represents PMT QE
 
         self.drift_velocity = fd_nest.calculate_drift_velocity(
-            self.drift_field, self.density, self.temperature, self.detector)
-        self.extraction_eff = fd_nest.calculate_extraction_eff(self.gas_field, self.temperature)
-        self.g2 = fd_nest.calculate_g2(self.gas_field, self.density_gas, self.gas_gap,
-                                       self.g1_gas, self.extraction_eff)
+            self.drift_field, self.density, self.temperature, self.detector
+        )
+        self.extraction_eff = fd_nest.calculate_extraction_eff(
+            self.gas_field, self.temperature
+        )
+        self.g2 = fd_nest.calculate_g2(
+            self.gas_field,
+            self.density_gas,
+            self.gas_gap,
+            self.g1_gas,
+            self.extraction_eff,
+        )
 
     def s1_posDependence(self, z):
         """
@@ -63,19 +89,19 @@ class XLZDSource:
         BACCARAT.
         Requires z to be in cm, and in the FV.
         """
-        if self.configuration == '80t':
+        if self.configuration == "80t":
             a = 4.93526997e-01
             b = 5.58488459e-04
             c = -1.06051830e-07
             d = -1.02545243e-08
             e = -1.30897496e-11
-        elif self.configuration == '60t':
+        elif self.configuration == "60t":
             a = 5.00828879e-01
             b = 4.25478465e-04
             c = 2.02171646e-07
             d = -1.31075129e-08
             e = -2.29858516e-11
-        elif self.configuration == '40t':
+        elif self.configuration == "40t":
             a = 5.68299226e-01
             b = 7.29787915e-05
             c = -4.37731127e-06
@@ -89,60 +115,70 @@ class XLZDSource:
     def add_extra_columns(self, d):
         super().add_extra_columns(d)
 
-        if self.configuration == '80t':
+        if self.configuration == "80t":
             LCE_average = 0.471
-        elif self.configuration == '60t':
+        elif self.configuration == "60t":
             LCE_average = 0.493
-        elif self.configuration == '40t':
+        elif self.configuration == "40t":
             LCE_average = 0.570
-        d['s1_pos_corr'] = self.s1_posDependence(d['z'].values) / LCE_average # normalise to volume-averaged LCE
+        d["s1_pos_corr"] = (
+            self.s1_posDependence(d["z"].values) / LCE_average
+        )  # normalise to volume-averaged LCE
 
-        if 's1' in d.columns and 'cs1' not in d.columns:
-            d['cs1'] = d['s1'] / d['s1_pos_corr']
-        if 's2' in d.columns and 'cs2' not in d.columns:
-            d['cs2'] = d['s2'] * np.exp(d['drift_time'] / self.elife)
+        if "s1" in d.columns and "cs1" not in d.columns:
+            d["cs1"] = d["s1"] / d["s1_pos_corr"]
+        if "s2" in d.columns and "cs2" not in d.columns:
+            d["cs2"] = d["s2"] * np.exp(d["drift_time"] / self.elife)
 
-        if 'cs1' in d.columns and 'cs2' in d.columns and 'ces_er_equivalent' not in d.columns:
-             d['ces_er_equivalent'] = (d['cs1'] / (self.g1 * LCE_average) + d['cs2'] / self.g2) * self.Wq_keV / (1. + self.double_pe_fraction)
+        if (
+            "cs1" in d.columns
+            and "cs2" in d.columns
+            and "ces_er_equivalent" not in d.columns
+        ):
+            d["ces_er_equivalent"] = (
+                (d["cs1"] / (self.g1 * LCE_average) + d["cs2"] / self.g2)
+                * self.Wq_keV
+                / (1.0 + self.double_pe_fraction)
+            )
 
 
 @export
 class XLZDERSource(XLZDSource, fd.nest.nestERSource):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
 class XLZDNRSource(XLZDSource, fd.nest.nestNRSource):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
 class XLZDERSourceGroup(XLZDSource, fd.nest.nestERSourceGroup):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
 class XLZDNRSourceGroup(XLZDSource, fd.nest.nestNRSourceGroup):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
@@ -153,21 +189,46 @@ class XLZDNRSourceGroup(XLZDSource, fd.nest.nestNRSourceGroup):
 
 @export
 class XLZDWIMPSource(XLZDSource, fd.nest.nestWIMPSource):
-    def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        *args,
+        wimp_mass=50.0,
+        min_E=1e-2,
+        max_E=40.0,
+        sigma=1.0,
+        n_bins_energy=800,
+        n_bins_time=25,
+        modulation=False,
+        fid_mass=1.0,
+        livetime=1.0,
+        detector="xlzd",
+        configuration="80t",
+        **kwargs
+    ):
+        super().__init__(
+            *args,
+            wimp_mass=wimp_mass,
+            min_E=min_E,
+            max_E=max_E,
+            sigma=sigma,
+            n_bins_energy=n_bins_energy,
+            n_bins_time=n_bins_time,
+            modulation=modulation,
+            fid_mass=fid_mass,
+            livetime=livetime,
+            detector=detector,
+            configuration=configuration,
+            **kwargs
+        )
 
 
 @export
 class XLZDSolarAxionSource(XLZDSource, fd.nest.nestSolarAxionSource):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
@@ -179,53 +240,55 @@ class XLZDSolarAxionSource(XLZDSource, fd.nest.nestSolarAxionSource):
 @export
 class XLZDXe136Source(XLZDSource, fd.nest.Xe136Source):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
 class XLZDPb214Source(XLZDSource, fd.nest.Pb214Source):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
 class XLZDKr85Source(XLZDSource, fd.nest.Kr85Source):
     def __init__(self, *args, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
         super().__init__(*args, **kwargs)
 
 
 @export
-class XLZDvERSource(XLZDSource, fd.nest.vERSource, fd.nest.nestTemporalRateOscillationERSource):
+class XLZDvERSource(
+    XLZDSource, fd.nest.vERSource, fd.nest.nestTemporalRateOscillationERSource
+):
     def __init__(self, *args, amplitude=None, phase_ns=None, period_ns=None, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
 
         if amplitude is None:
-            self.amplitude = 2. * 0.01671
+            self.amplitude = 2.0 * 0.01671
         else:
             self.amplitude = amplitude
 
         if phase_ns is None:
-            self.phase_ns = pd.to_datetime('2022-01-04T00:00:00').value
+            self.phase_ns = pd.to_datetime("2022-01-04T00:00:00").value
         else:
             self.phase_ns = phase_ns
 
         if period_ns is None:
-            self.period_ns = 1. * 3600. * 24. * 365.25 * 1e9
+            self.period_ns = 1.0 * 3600.0 * 24.0 * 365.25 * 1e9
         else:
             self.period_ns = period_ns
 
@@ -233,25 +296,27 @@ class XLZDvERSource(XLZDSource, fd.nest.vERSource, fd.nest.nestTemporalRateOscil
 
 
 @export
-class XLZDvNRSolarSource(XLZDSource, fd.nest.vNRSolarSource, fd.nest.nestTemporalRateOscillationNRSource):
+class XLZDvNRSolarSource(
+    XLZDSource, fd.nest.vNRSolarSource, fd.nest.nestTemporalRateOscillationNRSource
+):
     def __init__(self, *args, amplitude=None, phase_ns=None, period_ns=None, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
 
         if amplitude is None:
-            self.amplitude = 2. * 0.01671
+            self.amplitude = 2.0 * 0.01671
         else:
             self.amplitude = amplitude
 
         if phase_ns is None:
-            self.phase_ns = pd.to_datetime('2022-01-04T00:00:00').value
+            self.phase_ns = pd.to_datetime("2022-01-04T00:00:00").value
         else:
             self.phase_ns = phase_ns
 
         if period_ns is None:
-            self.period_ns = 1. * 3600. * 24. * 365.25 * 1e9
+            self.period_ns = 1.0 * 3600.0 * 24.0 * 365.25 * 1e9
         else:
             self.period_ns = period_ns
 
@@ -259,25 +324,27 @@ class XLZDvNRSolarSource(XLZDSource, fd.nest.vNRSolarSource, fd.nest.nestTempora
 
 
 @export
-class XLZDvNROtherSource(XLZDSource, fd.nest.vNROtherSource, fd.nest.nestTemporalRateOscillationNRSource):
+class XLZDvNROtherSource(
+    XLZDSource, fd.nest.vNROtherSource, fd.nest.nestTemporalRateOscillationNRSource
+):
     def __init__(self, *args, amplitude=None, phase_ns=None, period_ns=None, **kwargs):
-        if ('detector' not in kwargs):
-            kwargs['detector'] = 'xlzd'
-        if ('configuration' not in kwargs):
-            kwargs['configuration'] = '80t'
+        if "detector" not in kwargs:
+            kwargs["detector"] = "xlzd"
+        if "configuration" not in kwargs:
+            kwargs["configuration"] = "80t"
 
         if amplitude is None:
-            self.amplitude = 2. * 0.01671
+            self.amplitude = 2.0 * 0.01671
         else:
             self.amplitude = amplitude
 
         if phase_ns is None:
-            self.phase_ns = pd.to_datetime('2022-01-04T00:00:00').value
+            self.phase_ns = pd.to_datetime("2022-01-04T00:00:00").value
         else:
             self.phase_ns = phase_ns
 
         if period_ns is None:
-            self.period_ns = 1. * 3600. * 24. * 365.25 * 1e9
+            self.period_ns = 1.0 * 3600.0 * 24.0 * 365.25 * 1e9
         else:
             self.period_ns = period_ns
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.5
 scipy==1.9.3
 pandas==1.5.2
 multihist==0.6.5
-wimprates==0.4.1
+wimprates==0.5.0
 tqdm==4.64.1
 tensorflow==2.11.0
 tensorflow_probability==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy==1.9.3
 pandas==1.5.2
 multihist==0.6.5
 wimprates==0.5.0
+matplotlib
 tqdm==4.64.1
 tensorflow==2.11.0
 tensorflow_probability==0.19.0

--- a/wimprate_interface.ipynb
+++ b/wimprate_interface.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "426697b2-567b-44c0-936c-c6b7ab90e364",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flamedisx.nest import nestWIMPSource\n",
+    "import flamedisx as fd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fa892c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source = nestWIMPSource(wimp_mass=500, sigma=1e-45)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bac78671",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source.energy_hist.projection(1).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50a5ef11",
+   "metadata": {},
+   "source": [
+    "# Generating spectra from different parameter sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5726ba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case_1 = nestWIMPSource.get_energy_hist(wimp_mass=30, min_E=0, max_E=100, n_bins_energy=500, n_bins_time=30, sigma=1e-48)\n",
+    "case_2 = nestWIMPSource.get_energy_hist(wimp_mass=50, min_E=0, max_E=100, n_bins_energy=500, n_bins_time=30, sigma=1e-47)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "963f44cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case_1.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af2aed20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case_2.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f46e452",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case_1.projection(1).plot()\n",
+    "case_2.projection(1).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7753ef62",
+   "metadata": {},
+   "source": [
+    "# Generating spectra with and without modulation over 1 year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1381dba0-53d1-4e88-b2ce-f1783a5a479a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_mod_on = nestWIMPSource.get_energy_hist(modulation=True)\n",
+    "hist_mod_off = nestWIMPSource.get_energy_hist(modulation=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3bf62be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_mod_on.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "656eb7cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_mod_off.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4851d23b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_mod_on.projection(1).plot()\n",
+    "hist_mod_off.projection(1).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a563b291",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_mod_off.projection(0).plot()\n",
+    "hist_mod_on.projection(0).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37148e60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fd.relative_modulation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4389376",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fd.xlzd.XLZDWIMPSource()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR proposes the integration of the package [wimprates](https://github.com/JelleAalbers/wimprates) to automatically compute the energy spectrum of WIMP interactions within FlameNEST for a given set of parameters, including the option to simulate or not signal modulation due to the Earth's revolution around Sun.

Currently, modulation calculation assumes that the timespan in consideration is exaclty 1 year, regardless of the number of bins in time the user chooses.

This was implemented in the class static method `flamedisx.nest.nestWIMPSource.get_energy_hist` which is called during the `__init__()` method of the class itself.

The function `flamedisx.relative_modulation` has been added to `utils.py` and is called during the `get_energy_hist` method.